### PR TITLE
Do not allow empty names in `ldns_dname_new()`

### DIFF
--- a/dname.c
+++ b/dname.c
@@ -251,6 +251,9 @@ ldns_dname_new(uint16_t s, void *d)
 {
         ldns_rdf *rd;
 
+        if (!s || !d) {
+                return NULL;
+        }
         rd = LDNS_MALLOC(ldns_rdf);
         if (!rd) {
                 return NULL;


### PR DESCRIPTION
A name has to be at least 1 byte, so return `NULL` if this is not the case.

Before that change, we had a paradoxical situation where `ldns_dname_new(0, NULL)` returned a valid RDF pointer, but trying to use that pointer with functions such as `ldns_rdf_print()` had an undefined behavior.