### PR TITLE
fix certificate path issue with ldns-dane

### DIFF
--- a/examples/ldns-dane.c
+++ b/examples/ldns-dane.c
@@ -1692,6 +1692,14 @@ main(int argc, char* const* argv)
 	ctx =  SSL_CTX_new(SSLv23_client_method());
 #else
 	ctx =  SSL_CTX_new(TLS_client_method());
+	if ((CAfile || CApath)) {
+		if (SSL_CTX_load_verify_locations(
+				ctx, CAfile, CApath) != 1) {
+			ssl_err("error loading CA certificates");
+		}
+	} else {
+		SSL_CTX_set_default_verify_dir(ctx);
+	}
 	if (ctx && SSL_CTX_dane_enable(ctx) <= 0) {
 		ssl_err("could not SSL_CTX_dane_enable");
 	}


### PR DESCRIPTION
The libssl 1.1 calls did not contain the correct call to set the
certificate path, resulting in 'unable to get local issuer' errors on
many domains.

Als use the default path if no path or file is specified.

Example of the issue (run on a Debian system with libssl1.1);

pre-patch:

    > ./ldns-dane verify dnssec.nl 443 -p /etc/ssl/certs
    213.136.9.14 did not dane-validate, because: unable to get local issuer certificate
    2001:7b8:606:1:213:136:9:14 did not dane-validate, because: unable to get local issuer certificate
post-patch:

    > ./ldns-dane verify dnssec.nl 443 -p /etc/ssl/certs
    213.136.9.14 dane-validated successfully
    2001:7b8:606:1:213:136:9:14 dane-validated successfully
