### PR TITLE
include used openssl headers

### DIFF
--- a/dnssec.c
+++ b/dnssec.c
@@ -23,6 +23,11 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/md5.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#ifdef USE_DSA
+#include <openssl/dsa.h>
+#endif
 #endif
 
 ldns_rr *

--- a/dnssec_sign.c
+++ b/dnssec_sign.c
@@ -17,6 +17,11 @@
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/md5.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#ifdef USE_DSA
+#include <openssl/dsa.h>
+#endif
 #endif /* HAVE_SSL */
 
 ldns_rr *

--- a/host2str.c
+++ b/host2str.c
@@ -28,6 +28,14 @@
 #include <time.h>
 #include <sys/time.h>
 
+#ifdef HAVE_SSL
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#ifdef USE_DSA
+#include <openssl/dsa.h>
+#endif
+#endif
+
 #ifndef INET_ADDRSTRLEN
 #define INET_ADDRSTRLEN 16
 #endif

--- a/keys.c
+++ b/keys.c
@@ -17,6 +17,11 @@
 #ifdef HAVE_SSL
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#ifdef USE_DSA
+#include <openssl/dsa.h>
+#endif
 #ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
 #endif


### PR DESCRIPTION
The bn.h/dsa.h/rsa.h headers aren't included even though APIs from
them are used heavily.  Include them in files that need them.  If
we don't, we might hit build failures depending on how OpenSSL was
configured.