### PR TITLE
Devel/python bindings

### DIFF
--- a/contrib/python/ldns_key.i
+++ b/contrib/python/ldns_key.i
@@ -41,7 +41,7 @@
   $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr($1_key), SWIGTYPE_p_ldns_struct_key, SWIG_POINTER_OWN |  0 ));
 }
 
-%exception ldns_key_set_pubkey_owner(ldns_key *k, ldns_rdf *r)  %{ $action Py_INCREF(obj1); %}
+%typemap(argout) ldns_rdf *r "Py_INCREF($input);"
 
 %nodefaultctor ldns_struct_key; //no default constructor & destructor
 %nodefaultdtor ldns_struct_key;

--- a/contrib/python/ldns_rdf.i
+++ b/contrib/python/ldns_rdf.i
@@ -221,6 +221,7 @@
                         case LDNS_RDF_TYPE_EUI64:      return "EUI64";
                         case LDNS_RDF_TYPE_TAG:        return "TAG";
                         case LDNS_RDF_TYPE_LONG_STR:   return "LONG_STR";
+			case LDNS_RDF_TYPE_AMTRELAY:   return "AMTRELAY";
                         case LDNS_RDF_TYPE_CERTIFICATE_USAGE:
                             return "CERTIFICATE_USAGE";
                         case LDNS_RDF_TYPE_SELECTOR:   return "SELECTOR";


### PR DESCRIPTION
To address issue #7 .
It works but I get new (scary) warnings (but only with swig4):
```
./contrib/python/ldns_wrapper.c:1819:23: warning: cast between incompatible function types from ‘PyObject * (*)(PyObject *)’ {aka ‘struct _object * (*)(struct _object *)’} to ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} [-Wcast-function-type]
 1819 |   {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
      |                       ^
./contrib/python/ldns_wrapper.c:1820:23: warning: cast between incompatible function types from ‘PyObject * (*)(PyObject *)’ {aka ‘struct _object * (*)(struct _object *)’} to ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} [-Wcast-function-type]
 1820 |   {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"acquires ownership of the pointer"},
      |                       ^
./contrib/python/ldns_wrapper.c:1823:23: warning: cast between incompatible function types from ‘PyObject * (*)(PyObject *)’ {aka ‘struct _object * (*)(struct _object *)’} to ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} [-Wcast-function-type]
 1823 |   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
      |                       ^
./contrib/python/ldns_wrapper.c:1824:23: warning: cast between incompatible function types from ‘PyObject * (*)(SwigPyObject *)’ {aka ‘struct _object * (*)(struct <anonymous> *)’} to ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} [-Wcast-function-type]
 1824 |   {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
      |                       ^
./contrib/python/ldns_wrapper.c: In function ‘SWIG_Python_addvarlink’:
```