### PR TITLE
Use OpenSSL context options

### DIFF
--- a/dane.c
+++ b/dane.c
@@ -1,7 +1,7 @@
 /*
  * Verify or create TLS authentication with DANE (RFC6698)
  *
- * (c) NLnetLabs 2012
+ * (c) NLnetLabs 2012-2020
  *
  * See the file LICENSE for the license.
  *
@@ -27,6 +27,63 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
+#endif
+
+/* OpenSSL context options. At the moment, disable SSLv2, SSLv3
+ * and Compression, if available. TLSv1.0 is allowed at the moment.
+ * TLSv1.1 is the first to provide elliptic curves, so it is usually
+ * allowed in a TLS stack. TLSv1.2 is the first to provide authenc
+ * modes of operation, like GCM. The defines below are a moving
+ * target based on OpenSSL library version. Grep is useful to find
+ * the defines: grep -IR SSL_OP_NO_ /usr/include/openssl.
+ */
+#ifdef HAVE_SSL
+# ifdef SSL_OP_NO_SSLv2
+	const long NoOpenSSLv2 = SSL_OP_NO_SSLv2;
+# else
+	const long NoOpenSSLv2 = 0L;
+# endif
+# ifdef SSL_OP_NO_SSLv3
+	const long NoOpenSSLv3 = SSL_OP_NO_SSLv3;
+# else
+	const long NoOpenSSLv3 = 0L;
+# endif
+# ifdef SSL_OP_NO_TLSv1
+	const long NoOpenTLSv1 = SSL_OP_NO_TLSv1;
+# else
+	const long NoOpenTLSv1 = 0L;
+# endif
+# ifdef SSL_OP_NO_DTLSv1
+	const long NoOpenDTLSv1 = SSL_OP_NO_DTLSv1;
+# else
+	const long NoOpenDTLSv1 = 0L;
+# endif
+# ifdef SSL_OP_NO_COMPRESSION
+	const long NoOpenSSLCompression = SSL_OP_NO_COMPRESSION;
+# else
+	const long NoOpenSSLCompression = 0L;
+# endif
+#endif
+
+#ifdef USE_DANE_VERIFY
+static SSL_CTX*
+ldns_dane_new_ssl_context(void)
+{
+	SSL_CTX* ssl_ctx;
+
+	ssl_ctx = SSL_CTX_new(TLS_client_method());
+	if (ssl_ctx != NULL)
+	{
+		/* ldns allows TLS and DTLS v1.0 at the moment. Some may disagree.
+		 * Sometime in the future they may be disabled, too. Maybe
+		 * --disable-tlsv1 and --disable-dtlsv1 should be configure options.
+		 */
+		long flags = NoOpenSSLv2 | NoOpenSSLv3 | NoOpenSSLCompression;
+		SSL_CTX_set_options(ssl_ctx, flags);
+	}
+
+	return ssl_ctx;
+}
 #endif
 
 ldns_status
@@ -641,7 +698,7 @@ ldns_dane_verify_rr(const ldns_rr* tlsa_rr,
 	 * verification.  We use these undocumented means with the ldns
 	 * dane function prototypes which did only offline dane verification.
 	 */
-	if (!(ssl_ctx = SSL_CTX_new(TLS_client_method())))
+	if (!(ssl_ctx = ldns_dane_new_ssl_context()))
 		s = LDNS_STATUS_MEM_ERR;
 
 	else if (SSL_CTX_dane_enable(ssl_ctx) <= 0)
@@ -841,7 +898,7 @@ ldns_dane_verify(const ldns_rr_list* tlsas,
 	 * verification.  We use these undocumented means with the ldns
 	 * dane function prototypes which did only offline dane verification.
 	 */
-	if (!(ssl_ctx = SSL_CTX_new(TLS_client_method())))
+	if (!(ssl_ctx = ldns_dane_new_ssl_context()))
 		s = LDNS_STATUS_MEM_ERR;
 
 	else if (SSL_CTX_dane_enable(ssl_ctx) <= 0)


### PR DESCRIPTION
dane.c: Use OpenSSL context options

Make ldns aware of OpenSSL's SSL_OP_NO_SSLv2, SSL_OP_NO_SSLv3, SSL_OP_NO_TLSv1, SSL_OP_NO_DTLSv1 and SSL_OP_NO_COMPRESSION. Guard use of the defines in case the OpenSSL library changes them or removes them.

Add ldns_dane_new_ssl_context() to obtain context with SSL_CTX_new. Use NoOpenSSLv2, NoOpenSSLv3 and NoOpenSSLCompression on the context.