### PR TITLE
Fix 60-compile-builddir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,7 +352,8 @@ if grep VERSION_TEXT $ssldir/include/openssl/opensslv.h | grep "LibreSSL" >/dev/
 else
 	AC_MSG_RESULT([no])
 fi
-AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 ENGINE_load_cryptodev EVP_PKEY_keygen ECDSA_SIG_get0 EVP_MD_CTX_new EVP_PKEY_base_id DSA_SIG_set0 DSA_SIG_get0 EVP_dss1 DSA_get0_pqg DSA_get0_key OPENSSL_init_ssl OPENSSL_init_crypto ERR_load_crypto_strings CRYPTO_memcmp])
+AC_CHECK_HEADERS([openssl/ssl.h openssl/evp.h openssl/engine.h openssl/conf.h])
+AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 ENGINE_load_cryptodev EVP_PKEY_keygen ECDSA_SIG_get0 EVP_MD_CTX_new EVP_PKEY_base_id DSA_SIG_set0 DSA_SIG_get0 EVP_dss1 DSA_get0_pqg DSA_get0_key EVP_cleanup ENGINE_cleanup ENGINE_free CRYPTO_cleanup_all_ex_data ERR_free_strings CONF_modules_unload OPENSSL_init_ssl OPENSSL_init_crypto ERR_load_crypto_strings CRYPTO_memcmp])
 
 # for macosx, see if glibtool exists and use that
 # BSD's need to know the version...
@@ -386,10 +387,18 @@ if test -n "$ssldir"; then
 fi
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <string.h>
+#ifdef HAVE_OPENSSL_SSL_H
 #include <openssl/ssl.h>
+#endif
+#ifdef HAVE_OPENSSL_EVP_H
 #include <openssl/evp.h>
+#endif
+#ifdef HAVE_OPENSSL_ENGINE_H
 #include <openssl/engine.h>
+#endif
+#ifdef HAVE_OPENSSL_CONF_H
 #include <openssl/conf.h>
+#endif
 /* routine to load gost (from sldns) */
 int load_gost_id(void)
 {
@@ -1108,5 +1117,3 @@ AC_OUTPUT
 COPY_HEADER_FILES(ldns/, ldns/)
 
 dnl AC_CONFIG_SUBDIRS([drill])
-
-

--- a/drill/drill.c
+++ b/drill/drill.c
@@ -995,9 +995,15 @@ main(int argc, char *argv[])
 
 #ifdef HAVE_SSL
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(HAVE_LIBRESSL)
-	CRYPTO_cleanup_all_ex_data();
-	ERR_free_strings();
-	EVP_cleanup();
+#ifdef HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
+	CRYPTO_cleanup_all_ex_data ();
+#endif
+#ifdef HAVE_ERR_FREE_STRINGS
+	ERR_free_strings ();
+#endif
+#ifdef HAVE_EVP_CLEANUP
+	EVP_cleanup ();
+#endif
 #endif
 #endif
 #ifdef USE_WINSOCK

--- a/examples/ldns-signzone.c
+++ b/examples/ldns-signzone.c
@@ -536,14 +536,26 @@ static void
 shutdown_openssl ( ENGINE * const e )
 {
 	if ( e != NULL ) {
+#ifdef HAVE_ENGINE_FREE
 		ENGINE_free ( e );
+#endif
+#ifdef HAVE_ENGINE_CLEANUP
 		ENGINE_cleanup ();
+#endif
 	}
 
+#ifdef HAVE_CONF_MODULES_UNLOAD
 	CONF_modules_unload ( 1 );
+#endif
+#ifdef HAVE_EVP_CLEANUP
 	EVP_cleanup ();
+#endif
+#ifdef HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
 	CRYPTO_cleanup_all_ex_data ();
+#endif
+#ifdef HAVE_ERR_FREE_STRINGS
 	ERR_free_strings ();
+#endif
 }
 #endif
 
@@ -1006,11 +1018,15 @@ main(int argc, char *argv[])
 #ifdef HAVE_SSL
 		if (ERR_peek_error()) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(HAVE_LIBRESSL)
+#ifdef HAVE_ERR_LOAD_CRYPTO_STRINGS
 			ERR_load_crypto_strings();
+#endif
 #endif
 			ERR_print_errors_fp(stderr);
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(HAVE_LIBRESSL)
-			ERR_free_strings();
+#ifdef HAVE_ERR_FREE_STRINGS
+			ERR_free_strings ();
+#endif
 #endif
 		}
 #endif
@@ -1033,7 +1049,9 @@ main(int argc, char *argv[])
 	shutdown_openssl ( engine );
 #else
 #if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(HAVE_LIBRESSL)
-	CRYPTO_cleanup_all_ex_data();
+#ifdef HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
+	CRYPTO_cleanup_all_ex_data ();
+#endif
 #endif
 #endif
 

--- a/test/60-compile-builddir.tpkg/60-compile-builddir.test
+++ b/test/60-compile-builddir.tpkg/60-compile-builddir.test
@@ -30,6 +30,5 @@ fi;
 
 make realclean || true
 $loot && $conf && mkdir -p b && cd b && \
-	../configure CFLAGS="-Werror=implicit-function-declaration  -DOPENSSL_API_COMPAT=0x10100000L" --with-drill --with-examples --disable-gost --disable-dane-ta-usage && \
+	../configure CFLAGS="-Werror=implicit-function-declaration  -DOPENSSL_API_COMPAT=0x10100000L" --with-drill --with-examples --disable-gost --disable-dane-verify --disable-dane-ta-usage && \
 	$mk
-


### PR DESCRIPTION
This PR fixes the build failure in 60-compile-builddir. Also see [Issue #79](https://github.com/NLnetLabs/ldns/issues/79).

The essence of the PR is to test for functions like `EVP_cleanup` and `ENGINE_cleanup`. It also adds `--disable-dane-verify`.

I *think* both `--disable-dane-verify` (added with PR) and `--disable-dane-ta-usage` (existing in test) could be tied to `HAVE_SSL` to automatically disable tests when OpenSSL or LibreSSL are not available. However, this PR does not make the change.

This PR should also clear the test failures in [PR #78](https://github.com/NLnetLabs/ldns/pull/78) and [PR #75](https://github.com/NLnetLabs/ldns/pull/75).