### PR TITLE
Fix undefined reference to "rpl_malloc"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -840,8 +840,9 @@ AC_CHECK_TYPE(in_port_t, [], [AC_DEFINE([in_port_t], [uint16_t], [in_port_t])], 
 #endif])
 ACX_CHECK_SS_FAMILY
 
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
+# AC_FUNC_MALLOC suffers false failures and causes Asan failures.
+# AC_FUNC_MALLOC
+# AC_FUNC_REALLOC
 
 AC_REPLACE_FUNCS(b64_pton)
 AC_REPLACE_FUNCS(b64_ntop)


### PR DESCRIPTION
This PR fixes one of the Asan test failures.

The Asan test for this PR is:

```
13-unit-tests-base.o: In function `test_base64_encode':
/home/travis/build/noloader/ldns/test/13-unit-tests-base.cYieJC/./13-unit-tests-base.c:26: undefined reference to `rpl_malloc'
13-unit-tests-base.o: In function `test_base64_decode':
/home/travis/build/noloader/ldns/test/13-unit-tests-base.cYieJC/./13-unit-tests-base.c:68: undefined reference to `rpl_malloc'
13-unit-tests-base.o: In function `test_base32_encode':
/home/travis/build/noloader/ldns/test/13-unit-tests-base.cYieJC/./13-unit-tests-base.c:118: undefined reference to `rpl_malloc'
/home/travis/build/noloader/ldns/test/13-unit-tests-base.cYieJC/./13-unit-tests-base.c:118: undefined reference to `rpl_malloc'
```

The other failure - the memory leaks in `ldns_rr_new` and `ldns_rdf_new_frm_data` - are still present. Another PR will fix them.