### PR TITLE
Clear errors and warnings for SHA-1 and SHA-256

### DIFF
--- a/ldns/sha1.h
+++ b/ldns/sha1.h
@@ -1,6 +1,13 @@
 #ifndef LDNS_SHA1_H
 #define LDNS_SHA1_H
 
+#include <stdint.h>  /* uint32_t and friends */
+#include <stddef.h>  /* size_t and NULL */
+
+#if LDNS_BUILD_CONFIG_HAVE_INTTYPES_H
+# include <inttypes.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,7 +36,7 @@ void ldns_sha1_final(unsigned char digest[LDNS_SHA1_DIGEST_LENGTH], ldns_sha1_ct
  *             available
  * \return the SHA1 digest of the given data
  */
-unsigned char *ldns_sha1(unsigned char *data, unsigned int data_len, unsigned char *digest);
+unsigned char *ldns_sha1(const unsigned char *data, unsigned int data_len, unsigned char *digest);
 
 #ifdef __cplusplus
 }

--- a/ldns/sha2.h
+++ b/ldns/sha2.h
@@ -46,23 +46,16 @@
 #ifndef __LDNS_SHA2_H__
 #define __LDNS_SHA2_H__
 
+#include <stdint.h>  /* uint32_t and friends */
+#include <stddef.h>  /* size_t and NULL */
+
+#if LDNS_BUILD_CONFIG_HAVE_INTTYPES_H
+# include <inttypes.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-/*
- * Import u_intXX_t size_t type definitions from system headers.  You
- * may need to change this, or define these things yourself in this
- * file.
- */
-#include <sys/types.h>
-
-#if LDNS_BUILD_CONFIG_HAVE_INTTYPES_H
-
-#include <inttypes.h>
-
-#endif /* LDNS_BUILD_CONFIG_HAVE_INTTYPES_H */
 
 
 /*** SHA-256/384/512 Various Length Definitions ***********************/
@@ -116,7 +109,7 @@ void ldns_sha512_final(uint8_t[LDNS_SHA512_DIGEST_LENGTH], ldns_sha512_CTX*);
  *             available
  * \return the SHA1 digest of the given data
  */
-unsigned char *ldns_sha256(unsigned char *data, unsigned int data_len, unsigned char *digest);
+unsigned char *ldns_sha256(const unsigned char *data, unsigned int data_len, unsigned char *digest);
 
 /**
  * Convenience function to digest a fixed block of data at once.
@@ -128,7 +121,7 @@ unsigned char *ldns_sha256(unsigned char *data, unsigned int data_len, unsigned 
  *             available
  * \return the SHA1 digest of the given data
  */
-unsigned char *ldns_sha384(unsigned char *data, unsigned int data_len, unsigned char *digest);
+unsigned char *ldns_sha384(const unsigned char *data, unsigned int data_len, unsigned char *digest);
 
 /**
  * Convenience function to digest a fixed block of data at once.
@@ -140,7 +133,7 @@ unsigned char *ldns_sha384(unsigned char *data, unsigned int data_len, unsigned 
  *             available
  * \return the SHA1 digest of the given data
  */
-unsigned char *ldns_sha512(unsigned char *data, unsigned int data_len, unsigned char *digest);
+unsigned char *ldns_sha512(const unsigned char *data, unsigned int data_len, unsigned char *digest);
 
 #ifdef	__cplusplus
 }

--- a/sha1.c
+++ b/sha1.c
@@ -168,7 +168,7 @@ ldns_sha1_final(unsigned char digest[LDNS_SHA1_DIGEST_LENGTH], ldns_sha1_ctx *co
 }
 
 unsigned char *
-ldns_sha1(unsigned char *data, unsigned int data_len, unsigned char *digest)
+ldns_sha1(const unsigned char *data, unsigned int data_len, unsigned char *digest)
 {
     ldns_sha1_ctx ctx;
     ldns_sha1_init(&ctx);

--- a/sha2.c
+++ b/sha2.c
@@ -621,7 +621,7 @@ void ldns_sha256_final(sha2_byte digest[], ldns_sha256_CTX* context) {
 }
 
 unsigned char *
-ldns_sha256(unsigned char *data, unsigned int data_len, unsigned char *digest)
+ldns_sha256(const unsigned char *data, unsigned int data_len, unsigned char *digest)
 {
     ldns_sha256_CTX ctx;
     ldns_sha256_init(&ctx);
@@ -935,7 +935,7 @@ void ldns_sha512_final(sha2_byte digest[], ldns_sha512_CTX* context) {
 }
 
 unsigned char *
-ldns_sha512(unsigned char *data, unsigned int data_len, unsigned char *digest)
+ldns_sha512(const unsigned char *data, unsigned int data_len, unsigned char *digest)
 {
     ldns_sha512_CTX ctx;
     ldns_sha512_init(&ctx);
@@ -988,7 +988,7 @@ void ldns_sha384_final(sha2_byte digest[], ldns_sha384_CTX* context) {
 }
 
 unsigned char *
-ldns_sha384(unsigned char *data, unsigned int data_len, unsigned char *digest)
+ldns_sha384(const unsigned char *data, unsigned int data_len, unsigned char *digest)
 {
     ldns_sha384_CTX ctx;
     ldns_sha384_init(&ctx);

--- a/test/13-unit-tests-base.tpkg/13-unit-tests-base.c
+++ b/test/13-unit-tests-base.tpkg/13-unit-tests-base.c
@@ -5,6 +5,10 @@
 
 #include <ldns/ldns.h>
 
+/* Avoid signedness warnings */
+#define CH_PTR(ptr) ((char*)(ptr))
+#define UCH_PTR(ptr) ((unsigned char*)(ptr))
+
 void print_data_ar(const uint8_t *data, const size_t len) {
 	size_t i;
 	
@@ -291,19 +295,18 @@ test_base32_decode_extended_hex(const char *str, const uint8_t *expect_data, siz
 
 
 int
-test_sha1(char *data, const char *expect_result_str)
+test_sha1(const void *data, const void *expect_result_str)
 {
 	int result;
-	char *digest, *d;
+	unsigned char *digest, *d;
 	unsigned int digest_len;
 	uint8_t *expect_result;
 	size_t data_len;
 	
 	data_len = strlen(data);
 
-	expect_result = malloc(strlen(expect_result_str) / 2);
+	expect_result = malloc(strlen(CH_PTR(expect_result_str)) / 2);
 	(void) ldns_hexstring_to_data(expect_result, expect_result_str);
-
 
 	digest_len = LDNS_SHA1_DIGEST_LENGTH;
 	digest = malloc(digest_len);
@@ -316,12 +319,12 @@ test_sha1(char *data, const char *expect_result_str)
 		printf("\n");
 		result = 1;
 	} else {
-		if (strncmp(expect_result, digest, digest_len) != 0) {
+		if (strncmp(CH_PTR(expect_result), CH_PTR(digest), digest_len) != 0) {
 			printf("Bad sha1 digest: got: ");
 			print_data_ar(digest, digest_len);
 			printf("Expected:                 ");
-			printf("%s\n", expect_result);
-			printf("Data:\t%s\n", data);
+			printf("%s\n", CH_PTR(expect_result));
+			printf("Data:\t%s\n", CH_PTR(data));
 			
 			result = 2;
 		} else {
@@ -334,17 +337,17 @@ test_sha1(char *data, const char *expect_result_str)
 }
 
 int
-test_sha256(char *data, const char *expect_result_str)
+test_sha256(const void *data, const void *expect_result_str)
 {
 	int result;
-	char *digest, *d;
+	unsigned char *digest, *d;
 	unsigned int digest_len;
 	uint8_t *expect_result;
 	size_t data_len;
 	
 	data_len = strlen(data);
 
-	expect_result = malloc(strlen(expect_result_str) / 2);
+	expect_result = malloc(strlen(CH_PTR(expect_result_str)) / 2);
 	(void) ldns_hexstring_to_data(expect_result, expect_result_str);
 
 	digest_len = LDNS_SHA256_DIGEST_LENGTH;
@@ -358,12 +361,12 @@ test_sha256(char *data, const char *expect_result_str)
 		printf("\n");
 		result = 1;
 	} else {
-		if (strncmp(expect_result, digest, digest_len) != 0) {
+		if (strncmp(CH_PTR(expect_result), CH_PTR(digest), digest_len) != 0) {
 			printf("Bad sha256 digest: got: ");
 			print_data_ar(digest, digest_len);
 			printf("Expected:                 ");
-			printf("%s\n", expect_result);
-			printf("Data:\t%s\n", data);
+			printf("%s\n", CH_PTR(expect_result));
+			printf("Data:\t%s\n", CH_PTR(data));
 			
 			result = 2;
 		} else {
@@ -380,8 +383,6 @@ main(void)
 {
 	uint8_t *data;
 	size_t data_len;
-	char *text;
-	size_t text_len;
 
 	int result = EXIT_SUCCESS;
 


### PR DESCRIPTION
This PR  accomplishes three things. First, it clears all the pointer-sign warnings in `13-unit-tests-base.c`. Second, it fixes const-ness in `ldns_sha1`, `ldns_sha256` and friends. Third, it fixes system includes so that using `ldns_sha1`, `ldns_sha256` and friends does not result in a compile error on some platforms.

For the third item, Posix includes are used for `uint32_t`, `NULL` and friends. Including `<inttypes.h>` or `<sys/types.h>` is not enough for some platforms. (When testing x86-sha-acceleration I was experiencing compile errors on the BSDs, OS X and Solaris).

This PR does not add additional functionality. It merely clears all the warnings in `13-unit-tests-base.c` and fixes compiles.

If the PR is accepted, I can merge it into x86-sha-acceleration. That has not been done at this point in case the PR is rejected.

(The failed Travis tests are expected at this point. There are outstanding UBsan and Asan findings. The sanitizers findings are getting cleared next).