### PR TITLE
Fix UBsan finding in ldns_serial_arithmitics_time (GH #71)

### DIFF
--- a/util.c
+++ b/util.c
@@ -295,10 +295,10 @@ ldns_gmtime64_r(int64_t clock, struct tm *result)
 static int64_t
 ldns_serial_arithmitics_time(int32_t time, time_t now)
 {
-	int32_t offset = time - (int32_t) now;
+	/* Casting due to https://github.com/NLnetLabs/ldns/issues/71 */
+	int32_t offset = (int32_t) ((uint32_t) time - (uint32_t) now);
 	return (int64_t) now + offset;
 }
-
 
 struct tm *
 ldns_serial_arithmitics_gmtime_r(int32_t time, time_t now, struct tm *result)


### PR DESCRIPTION
This PR clears a Undefined Behavior in `ldns_serial_arithmitics_time` by using unsigned types for the math. See https://github.com/NLnetLabs/ldns/issues/71 for the finding.

Also see the following from Unbound. A similar issue was cleared with `uint32_t` casts:

* https://github.com/NLnetLabs/unbound/issues/170
* https://github.com/NLnetLabs/unbound/commit/57bbbfc0e6d9

(The failed Travis tests are expected at this point. There are outstanding Asan findings. The sanitizers findings are getting cleared next).
