### PR TITLE
Fix Asan findings in 12-unit-tests-dnssec.c (GH #84)

### DIFF
--- a/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.c
+++ b/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.c
@@ -6,14 +6,14 @@
 #include <ldns/ldns.h>
 
 
-ldns_status 
+ldns_status
 check_ldns_calc_keytag_part(const char *key_str, uint16_t expected_keytag)
 {
+	ldns_rr *key_rr = NULL;
 	uint16_t keytag;
+
 	ldns_status result = LDNS_STATUS_OK;
-	
-	ldns_rr *key_rr;
-	
+
 	if (ldns_rr_new_frm_str(&key_rr, key_str, 0, NULL, NULL) !=
 			LDNS_STATUS_OK) {
 		printf("Key creation failed.");
@@ -28,32 +28,34 @@ check_ldns_calc_keytag_part(const char *key_str, uint16_t expected_keytag)
 			printf("%s\n", key_str);
 			result = LDNS_STATUS_ERR;
 		}
-		ldns_rr_free(key_rr);
 	}
-	
+
+	if (key_rr)
+		ldns_rr_free(key_rr);
+
 	return result;
 }
 
 ldns_status
-check_ldns_calc_keytag() 
+check_ldns_calc_keytag()
 {
 	const char *key_str;
 	uint16_t expected_keytag;
 
 	ldns_status result = LDNS_STATUS_OK;
-	
+
 	key_str = "jelte.nlnetlabs.nl. IN DNSKEY 256 3 5 AQOraLfzarHAlFskVGwAGnX0LRjlcOiO6y5WM4Kz+QvZ9vX28h4lOvnf d5tkxnZm7ERLTAJoFq+1w/wl7VXs2Isz75BSZ7LQh3OT2xXnS6VT5ZxX ko/UCOdoGiKZZ63jHZ0jNSTCYy8+5rfvwRD8s3gGuErp5KcHg3V8VLUK SDNNEQ==";
 	expected_keytag = 42860;
 	if (check_ldns_calc_keytag_part(key_str, expected_keytag) != LDNS_STATUS_OK) {
 		result = LDNS_STATUS_ERR;
 	}
-	
+
 	key_str = "sub.jelte.nlnetlabs.nl. IN DNSKEY 256 3 3 CI4CujZjrw4hjpAP8zMyntKEQJBV96M0OhZ5HCeZ5K46eGHEJUG6RglQ M2OVYY/qRqALDs/Ptzk+Hdb0oV3RF0+fUA5+R5gX1avgbhsEPhvIInYB OPsNaXWKMJarpH2b8xHkF4XQT4TdqAf8maQcKk/RujeKR6VnXbadZUNK +SZsNWSbaDuCHbT0rWpO9nVbfoQUnNWpk1hmOh4oIlFdBtBTPck3ND+g dQrj5eJcSx0zwqjJBJIC+JxWt2rFtIEztfHxmmjbeddC2TL41O/AFPJM vUh85dnd3b1gZRc5UvA7Z2I2+ZD16FjNrmuNkNEjnlet7oiJAC0fezzX sZYCjwHfEyeaS2YXGzzZCeQpMBzeBRh3eq8pVn8r4AaRcNt1gnXbVdjd TQvp5deIGoaAHMl3yy4n0QmXgRscSIsyfK9Gn7NrlGRlCxs9rfVwcWCD Nj2MuIComXGIUYJW+ck0Rhk9Sq6M3onhSjITY9/y/SpwBna6SLpFdpEm bLYKES4gShTxjtmhJSytH0pooq9qxJ8kyH+I";
 	expected_keytag = 13026;
 	if (check_ldns_calc_keytag_part(key_str, expected_keytag) != LDNS_STATUS_OK) {
 		result = LDNS_STATUS_ERR;
 	}
-	
+
 	key_str = "sub.sub.jelte.nlnetlabs.nl. IN DNSKEY 256 3 1 AQPIQ2SNclMqdHu8afxVdbIVR/20vlDp2ZcEK5xFxDKVTunuq8BLAPr4 FvnbBQ4AkNYchecNcmQvKi/jJ7xwWqyqMAU1l+d6mZUTF6sC0ug9WQ/Q zG93nOBVLwGbmGTTXhrE/pRhS/o16Ab20zsbcdAb7PChQXSgByJKvT8W XumJ3FdOLhwmqQAnFuMnZC71/HAc4WjA+2zG1SNXnbTnC8Q/4/Fg/ygh 2GjT9Cj0hhFR+A2Hf+RXvkKsDwhdxWwJfW+IhAHUtwNKydsEvZM5UR2I PSytfzZ/fWKEx5BlxLZZNKzoeBtFHjHSeZU5Lb5DFnQJx5lcsd5MP2e8 +ppjVlg3";
 	expected_keytag = 22104;
 	if (check_ldns_calc_keytag_part(key_str, expected_keytag) != LDNS_STATUS_OK) {
@@ -67,22 +69,21 @@ check_ldns_calc_keytag()
 		result = LDNS_STATUS_ERR;
 	}
 */
-	
+
 	return result;
 }
 
 ldns_status
 check_ldns_canonicalization()
 {
-	const char *rr_str1 = "bla.nl. 1000 IN NS ns1.bla.nl.";
-	const char *rr_str2 = "BLA.NL. 1000 IN NS NS1.BlA.Nl.";
-	
-	ldns_rr *rr1, *rr2;
-	ldns_status status = LDNS_STATUS_ERR;
-	
-	status = ldns_rr_new_frm_str(&rr1, rr_str1, 0, NULL, NULL);
+	const char rr_str1[] = "bla.nl. 1000 IN NS ns1.bla.nl.";
+	const char rr_str2[] = "BLA.NL. 1000 IN NS NS1.BlA.Nl.";
 
+	ldns_rr *rr1 = NULL, *rr2 = NULL;
+	ldns_status status = LDNS_STATUS_ERR;
 	int diff;
+
+	status = ldns_rr_new_frm_str(&rr1, rr_str1, 0, NULL, NULL);
 
 	if (status != LDNS_STATUS_OK) {
 		fprintf(stdout, "Error constructing rr: %s\n", rr_str1);
@@ -100,16 +101,24 @@ check_ldns_canonicalization()
 	diff = ldns_rr_compare(rr1, rr2);
 	if (diff != 0) {
 		printf("Error, canonicalization does not work\n");
-		return LDNS_STATUS_ERR;
+		status = LDNS_STATUS_ERR;
 	} else {
-		return LDNS_STATUS_OK;
+		status = LDNS_STATUS_OK;
 	}
+
+	if (rr1)
+		ldns_rr_free(rr1);
+
+	if (rr2)
+		ldns_rr_free(rr2);
+
+	return status;
 }
 
 int main(void)
 {
 	int result = EXIT_SUCCESS;
-	
+
 	if (check_ldns_calc_keytag() != LDNS_STATUS_OK) {
 		printf("ldns_calc_keytag() failed.\n");
 		result = EXIT_FAILURE;


### PR DESCRIPTION
Asan testing is producing some findings in `12-unit-tests-dnssec.c`. Also see [Travis test results](https://travis-ci.com/NLnetLabs/ldns/jobs/293788254).

```
==5141==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f913b6fbb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f913b3cce4a in ldns_rr_new rr.c:27

Indirect leak of 48 byte(s) in 2 object(s) allocated from:
    #0 0x7f913b6fbb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f913b3c5b4d in ldns_rdf_new_frm_data rdata.c:203

Indirect leak of 20 byte(s) in 2 object(s) allocated from:
    #0 0x7f913b6fbb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f913b3c5b61 in ldns_rdf_new_frm_data rdata.c:207

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f913b6fbb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f913b3cd015 in ldns_rr_push_rdf rr.c:860

SUMMARY: AddressSanitizer: 124 byte(s) leaked in 6 allocation(s).
```

Also see [Issue 84](https://github.com/NLnetLabs/ldns/issues/84).