### PR TITLE
Add Android testing to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: c
+
+git:
+  depth: 5
+
 addons:
   apt:
     packages:
@@ -93,12 +97,92 @@ jobs:
       arch: s390x
       dist: bionic
       env: VALGRIND=true  ANALYSIS=true  COVERAGE=true  DOXYGEN=true
+    - os: linux
+      name: Android armv7a, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - ANDROID=yes
+        - AUTOTOOLS_HOST=armv7a-linux-androideabi
+        - OPENSSL_HOST=android-arm
+        - ANDROID_CPU=armv7a
+        - ANDROID_API=23
+        - ANDROID_PREFIX="$HOME/android$ANDROID_API-$ANDROID_CPU"
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+    - os: linux
+      name: Android aarch64, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - ANDROID=yes
+        - AUTOTOOLS_HOST=aarch64-linux-android
+        - OPENSSL_HOST=android-arm64
+        - ANDROID_CPU=aarch64
+        - ANDROID_API=23
+        - ANDROID_PREFIX="$HOME/android$ANDROID_API-$ANDROID_CPU"
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+    - os: linux
+      name: Android x86, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - ANDROID=yes
+        - AUTOTOOLS_HOST=i686-linux-android
+        - OPENSSL_HOST=android-x86
+        - ANDROID_CPU=x86
+        - ANDROID_API=23
+        - ANDROID_PREFIX="$HOME/android$ANDROID_API-$ANDROID_CPU"
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+    - os: linux
+      name: Android x86_64, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - ANDROID=yes
+        - AUTOTOOLS_HOST=x86_64-linux-android
+        - OPENSSL_HOST=android-x86_64
+        - ANDROID_CPU=x86_64
+        - ANDROID_API=23
+        - ANDROID_PREFIX="$HOME/android$ANDROID_API-$ANDROID_CPU"
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+
+before_script:
+  - |
+    if [ "$ANDROID" = "yes" ]; then
+      ./contrib/android/install_tools.sh
+    fi
 
 script:
   - |
     if [ "$UBSAN" = "true" ]; then
       export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover"
+      ./test/test_ci.sh
     elif [ "$ASAN" = "true" ]; then
       export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address"
+      ./test/test_ci.sh
+    elif [ "$ANDROID" = "yes" ]; then
+      export AUTOTOOLS_BUILD="$(./config.guess)"
+      export PKG_CONFIG_PATH="$ANDROID_PREFIX/lib/pkgconfig"
+      ./contrib/android/install_ndk.sh
+      source ./contrib/android/setenv_android.sh
+      ./contrib/android/install_openssl.sh
+      ./contrib/android/bootstrap_ldns.sh
+      ./configure \
+        --build="$AUTOTOOLS_BUILD" --host="$AUTOTOOLS_HOST" \
+        --prefix="$ANDROID_PREFIX" \
+        --with-ssl="$ANDROID_PREFIX" --disable-gost \
+        --with-drill --with-examples
+      make -j 2
+      make install
+    else
+      # Default case for mosts tests
+      ./test/test_ci.sh
     fi
-    test/test_ci.sh

--- a/Makefile.in
+++ b/Makefile.in
@@ -40,10 +40,24 @@ edit = sed \
 # override $U variable which is used by autotools for deansification (for
 # K&R C compilers), but causes problems if $U is defined in the env).
 U=
+
+# set all of the tools due to cross-compiles. libtool uses most of them.
+# https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
 CC 		= @CC@
+CXX		= @CXX@
+CPP		= @CPP@
+LD 		= @LD@
+AS 		= @AS@
+AR 		= @AR@
+RANLIB	= @RANLIB@
+STRIP	= @STRIP@
+
+# Unbound project specific flags
 CFLAGS		= @CFLAGS@
 CPPFLAGS	= -I. -I$(srcdir) @CPPFLAGS@ @DEFS@ -DLDNS_TRUST_ANCHOR_FILE="\"$(LDNS_TRUST_ANCHOR_FILE)\""
+ARFLAGS		= @ARFLAGS@
 LDFLAGS		= @LDFLAGS@
+
 LIBS 		= @LIBS@
 LIBOBJDIR	= compat/
 LIBOBJS		= @LIBOBJS@
@@ -72,15 +86,15 @@ LINTFLAGS       += -D"__BEGIN_DECLS=" -D"__ssize_t=ssize_t" -D"__intptr_t=intptr
 LINTFLAGS       += -D"_RuneLocale=int"
 DEPFLAG		= @DEPFLAG@
 
-INSTALL		= $(srcdir)/install-sh 
+INSTALL		= $(srcdir)/install-sh
 
 LIBLOBJS	= $(LIBOBJS:.o=.lo)
-LDNS_LOBJS	= buffer.lo dane.lo dname.lo dnssec.lo dnssec_sign.lo dnssec_verify.lo dnssec_zone.lo duration.lo error.lo higher.lo host2str.lo host2wire.lo keys.lo net.lo packet.lo parse.lo radix.lo rbtree.lo rdata.lo resolver.lo rr.lo rr_functions.lo sha1.lo sha2.lo str2host.lo tsig.lo update.lo util.lo wire2host.lo zone.lo 
+LDNS_LOBJS	= buffer.lo dane.lo dname.lo dnssec.lo dnssec_sign.lo dnssec_verify.lo dnssec_zone.lo duration.lo error.lo higher.lo host2str.lo host2wire.lo keys.lo net.lo packet.lo parse.lo radix.lo rbtree.lo rdata.lo resolver.lo rr.lo rr_functions.lo sha1.lo sha2.lo str2host.lo tsig.lo update.lo util.lo wire2host.lo zone.lo
 LDNS_LOBJS_EX	= ^linktest\.c$$
 LDNS_ALL_LOBJS	= $(LDNS_LOBJS) $(LIBLOBJS)
 LIB		= libldns.la
 
-LDNS_HEADERS	= buffer.h dane.h dname.h dnssec.h dnssec_sign.h dnssec_verify.h dnssec_zone.h duration.h error.h higher.h host2str.h host2wire.h keys.h ldns.h packet.h parse.h radix.h rbtree.h rdata.h resolver.h rr_functions.h rr.h sha1.h sha2.h str2host.h tsig.h update.h wire2host.h zone.h 
+LDNS_HEADERS	= buffer.h dane.h dname.h dnssec.h dnssec_sign.h dnssec_verify.h dnssec_zone.h duration.h error.h higher.h host2str.h host2wire.h keys.h ldns.h packet.h parse.h radix.h rbtree.h rdata.h resolver.h rr_functions.h rr.h sha1.h sha2.h str2host.h tsig.h update.h wire2host.h zone.h
 LDNS_HEADERS_EX	= ^config\.h|common\.h|util\.h|net\.h$$
 LDNS_HEADERS_GEN= common.h util.h net.h
 
@@ -89,8 +103,8 @@ PYLDNS_I_FILES	= $(pywrapdir)/file_py3.i $(pywrapdir)/ldns_buffer.i $(pywrapdir)
 DRILL_LOBJS	= drill/chasetrace.lo drill/dnssec.lo drill/drill.lo drill/drill_util.lo drill/error.lo drill/root.lo drill/securetrace.lo drill/work.lo
 
 EXAMPLE_LOBJS	= examples/ldns-chaos.lo examples/ldns-compare-zones.lo examples/ldns-dane.lo examples/ldnsd.lo examples/ldns-dpa.lo examples/ldns-gen-zone.lo examples/ldns-key2ds.lo examples/ldns-keyfetcher.lo examples/ldns-keygen.lo examples/ldns-mx.lo examples/ldns-notify.lo examples/ldns-nsec3-hash.lo examples/ldns-read-zone.lo examples/ldns-resolver.lo examples/ldns-revoke.lo examples/ldns-rrsig.lo examples/ldns-signzone.lo examples/ldns-test-edns.lo examples/ldns-testns.lo examples/ldns-testpkts.lo examples/ldns-update.lo examples/ldns-verify-zone.lo examples/ldns-version.lo examples/ldns-walk.lo examples/ldns-zcat.lo examples/ldns-zsplit.lo
-EXAMPLE_PROGS	= examples/ldns-chaos examples/ldns-compare-zones examples/ldnsd examples/ldns-gen-zone examples/ldns-key2ds examples/ldns-keyfetcher examples/ldns-keygen examples/ldns-mx examples/ldns-notify examples/ldns-read-zone examples/ldns-resolver examples/ldns-rrsig examples/ldns-test-edns examples/ldns-update examples/ldns-version examples/ldns-walk examples/ldns-zcat examples/ldns-zsplit 
-EX_PROGS_BASENM	= ldns-chaos ldns-compare-zones ldns-dane ldnsd ldns-dpa ldns-gen-zone ldns-key2ds ldns-keyfetcher ldns-keygen ldns-mx ldns-notify ldns-nsec3-hash ldns-read-zone ldns-resolver ldns-revoke ldns-rrsig ldns-signzone ldns-test-edns ldns-testns ldns-testpkts ldns-update ldns-verify-zone ldns-version ldns-walk ldns-zcat ldns-zsplit 
+EXAMPLE_PROGS	= examples/ldns-chaos examples/ldns-compare-zones examples/ldnsd examples/ldns-gen-zone examples/ldns-key2ds examples/ldns-keyfetcher examples/ldns-keygen examples/ldns-mx examples/ldns-notify examples/ldns-read-zone examples/ldns-resolver examples/ldns-rrsig examples/ldns-test-edns examples/ldns-update examples/ldns-version examples/ldns-walk examples/ldns-zcat examples/ldns-zsplit
+EX_PROGS_BASENM	= ldns-chaos ldns-compare-zones ldns-dane ldnsd ldns-dpa ldns-gen-zone ldns-key2ds ldns-keyfetcher ldns-keygen ldns-mx ldns-notify ldns-nsec3-hash ldns-read-zone ldns-resolver ldns-revoke ldns-rrsig ldns-signzone ldns-test-edns ldns-testns ldns-testpkts ldns-update ldns-verify-zone ldns-version ldns-walk ldns-zcat ldns-zsplit
 EXAMPLE_PROGS_EX= ^examples/ldns-testpkts\.c|examples/ldns-testns\.c|examples/ldns-dane\.c|examples/ldns-dpa\.c|examples/ldns-nsec3-hash\.c|examples/ldns-revoke\.c|examples/ldns-signzone\.c|examples/ldns-verify-zone\.c$$
 TESTNS		= examples/ldns-testns
 TESTNS_LOBJS	= examples/ldns-testns.lo examples/ldns-testpkts.lo
@@ -118,6 +132,10 @@ all:	setup-builddir lib linktest manpages @P5_DNS_LDNS@ @PYLDNS@ @DRILL@ @EXAMPL
 .c.lo:
 	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $< -o $@
 
+# Need libtool compile
+.c.o:
+	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $< -o $@
+
 $(LDNS_LOBJS) $(LIBLOBJS) $(DRILL_LOBJS) $(EXAMPLE_LOBJS):
 	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $(srcdir)/$(@:.lo=.c) -o $@
 
@@ -130,12 +148,14 @@ setup-builddir:
 	@if test ! -d include ; then $(INSTALL) -d include; fi
 	@if test ! -h include/ldns ; then ln -s ../ldns include/ldns || echo "include/ldns exists"; fi
 
+# builddir/ is used by 60-compile-builddir
 putdown-builddir:
 	rm -f include/ldns lib config.h
 	test ! -d include  || rmdir include  || :
 	if test -d examples -a ! -f examples/README; then rmdir examples || : ; fi
 	if test -d drill    -a ! -f drill/README   ; then rmdir drill    || : ; fi
 	if test -d compat   -a ! -f compat/malloc.c; then rmdir compat   || : ; fi
+	rm -rf builddir/
 
 drill: no-drill-config-h drill/drill drill/drill.1
 no-drill-config-h:
@@ -148,7 +168,7 @@ no-drill-config-h:
 	fi
 
 drill/drill: $(DRILL_LOBJS) $(LIB) $(LIBLOBJS)
-	$(LINK_EXE) $(DRILL_LOBJS) $(LIBLOBJS) $(LIBS) $(LIBSSL_LIBS) -lldns -o drill/drill
+	$(LINK_EXE) $(DRILL_LOBJS) $(LIBLOBJS) -lldns $(LIBSSL_LIBS) $(LIBS) -o drill/drill
 
 drill/drill.1: $(srcdir)/drill/drill.1.in
 	$(edit) $(srcdir)/drill/drill.1.in > drill/drill.1
@@ -178,22 +198,25 @@ no-examples-config-h:
 	     exit -1 ; \
 	fi
 
+# Need LIBSSL_LIBS
 $(EXAMPLE_PROGS):
-	$(LINK_EXE) $@.lo $(LIBLOBJS) $(LIBS) -lldns -o $@
+	$(LINK_EXE) $@.lo $(LIBLOBJS) -lldns $(LIBSSL_LIBS) $(LIBS) -o $@
 
+# Need LIBSSL_LIBS
 $(TESTNS):
-	$(LINK_EXE) $(TESTNS_LOBJS) $(LIBLOBJS) $(LIBS) -lldns -o $(TESTNS)
+	$(LINK_EXE) $(TESTNS_LOBJS) $(LIBLOBJS) -lldns $(LIBSSL_LIBS) $(LIBS) -o $(TESTNS)
 
+# Need LIBSSL_LIBS
 $(LDNS_DPA):
-	$(LINK_EXE) $(LDNS_DPA_LOBJS) $(LIBLOBJS) $(LIBS) $(LIBPCAP_LIBS) -lldns \
+	$(LINK_EXE) $(LDNS_DPA_LOBJS) $(LIBLOBJS) -lldns $(LIBPCAP_LIBS) $(LIBSSL_LIBS) $(LIBS) \
 		 -o $(LDNS_DPA)
 
 $(LDNS_DANE):
-	$(LINK_EXE) $(LDNS_DANE_LOBJS) $(LIBLOBJS) -lldns $(LIBS) $(LIBSSL_SSL_LIBS) \
+	$(LINK_EXE) $(LDNS_DANE_LOBJS) $(LIBLOBJS) -lldns $(LIBSSL_SSL_LIBS) $(LIBS) \
 		 -o $(LDNS_DANE)
 
 $(EX_SSL_PROGS):
-	$(LINK_EXE) $@.lo $(LIBLOBJS) $(LIBS) $(LIBSSL_LIBS) -lldns -o $@
+	$(LINK_EXE) $@.lo $(LIBLOBJS) -lldns $(LIBSSL_LIBS) $(LIBS) -o $@
 
 examples/ldns-dane.1: $(srcdir)/examples/ldns-dane.1.in
 	$(edit) $(srcdir)/examples/ldns-dane.1.in > examples/ldns-dane.1
@@ -221,14 +244,14 @@ uninstall-examples:
 	test ! -d $(DESTDIR)$(bindir) || rmdir -p $(DESTDIR)$(bindir) || : ;
 
 clean-examples:
-	$(LIBTOOL) --mode clean rm -f $(EXAMPLE_PROGS) 
+	$(LIBTOOL) --mode clean rm -f $(EXAMPLE_PROGS)
 	$(LIBTOOL) --mode clean rm -f $(TESTNS) $(LDNS_DPA) $(LDNS_DANE) $(EX_SSL_PROGS)
 	$(LIBTOOL) --mode clean rm -f $(EXAMPLE_LOBJS)
 	$(LIBTOOL) --mode clean rm -f examples/ldns-dane.1 examples/ldns-verify-zone.1
 
 linktest: $(srcdir)/linktest.c libldns.la
 	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $(srcdir)/linktest.c -o linktest.lo
-	$(LINK_EXE) linktest.lo $(LIBS) $(LIBSSL_LIBS) -lldns -o linktest
+	$(LINK_EXE) linktest.lo -lldns $(LIBSSL_LIBS) $(LIBS) -o linktest
 
 lib: libldns.la
 
@@ -252,7 +275,7 @@ doxygen:
 doc: manpages $(doxygen)
 	@$(INSTALL) -d doc
 
-manpages: $(srcdir)/doc/function_manpages 
+manpages: $(srcdir)/doc/function_manpages
 	@$(INSTALL) -d doc/man/man3
 	@if [ -f $(srcdir)/doc/man/man3/ldns_rr.3 ] ; \
 	then \
@@ -274,7 +297,7 @@ manpages: $(srcdir)/doc/function_manpages
 			| grep -v ^doxygen | grep -v ^cat  > doc/ldns_manpages; \
 	fi
 
-manpage-create-errors: $(srcdir)/doc/function_manpages 
+manpage-create-errors: $(srcdir)/doc/function_manpages
 	@$(INSTALL) -d doc
 	@cat $(srcdir)/ldns/*.h \
 	| $(srcdir)/doc/doxyparse.pl -e \
@@ -300,7 +323,7 @@ $(pywrapdir)/ldns_wrapper.c: $(PYLDNS_I_FILES) ldns/config.h
 ldns_wrapper.lo: $(pywrapdir)/ldns_wrapper.c ldns/config.h
 	$(COMP_LIB) -I./include/ldns $(LIBSSL_CPPFLAGS) $(PYTHON_CPPFLAGS) $(PYTHON_X_CFLAGS) -c $(pywrapdir)/ldns_wrapper.c -o $@
 
-_ldns.la: ldns_wrapper.lo libldns.la 
+_ldns.la: ldns_wrapper.lo libldns.la
 	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) $(PYTHON_CFLAGS) $(LDFLAGS) $(PYTHON_LDFLAGS) -module -version-info $(version_info) -no-undefined -o $@ ldns_wrapper.lo -rpath $(python_site) -L. -L.libs -lldns $(LIBS)
 
 $(p5_dns_ldns_dir)/Makefile: $(p5_dns_ldns_dir)/Makefile.PL
@@ -385,7 +408,7 @@ install-lib: lib
 	$(LIBTOOL) --mode=install cp libldns.la $(DESTDIR)$(libdir)
 	$(LIBTOOL) --mode=finish $(DESTDIR)$(libdir)
 
-uninstall-lib:	
+uninstall-lib:
 	$(LIBTOOL) --mode=uninstall rm -f $(DESTDIR)$(libdir)/libldns.la
 	test ! -d $(DESTDIR)$(libdir) || rmdir -p $(DESTDIR)$(libdir) || echo "ok, dir already gone"
 
@@ -395,7 +418,7 @@ install-pyldns: @PYLDNS@
 	$(LIBTOOL) --mode=install cp _ldns.la $(DESTDIR)$(python_site)
 	$(LIBTOOL) --mode=finish $(DESTDIR)$(python_site)
 
-uninstall-pyldns:	
+uninstall-pyldns:
 	rm -f $(DESTDIR)$(python_site)/ldns/*
 	test ! -d $(DESTDIR)$(python_site)/ldns || rmdir $(DESTDIR)$(python_site)/ldns || echo "ok, dir already gone"
 
@@ -450,7 +473,7 @@ docclean:
 	rm -f doc/ldns_manpages
 
 distclean: realclean
-	rm -fr autom4te.cache 
+	rm -fr autom4te.cache
 	rm -f config.guess config.sub configure ltmain.sh ldns/config.h.in
 
 ## No need for changes here

--- a/README-Travis.md
+++ b/README-Travis.md
@@ -1,0 +1,163 @@
+# Travis Testing
+
+LDNS 1.7.1 and above leverage Travis CI to increase coverage of compilers and platforms. Compilers include Clang and GCC; while platforms include Android, Linux, and OS X on AMD64, Aarch64, PowerPC and s390x hardware.
+
+Android is tested on armv7a, aarch64, x86 and x86_64. The Android recipes build and install OpenSSL and then builds and installs LDNS. The testing is tailored for Android NDK-r19 and above, and includes NDK-r20 and NDK-r21. Mips and Mips64 are not tested because they are no longer supported under current NDKs.
+
+The LDNS Travis configuration file `.travis.yml` does not use top-level keys like `os:` and `compiler:` so there is no matrix expansion. Instead LDNS specifies the exact job to run under the `jobs:` and `include:` keys.
+
+## Typical recipe
+
+A typical recipe tests Clang and GCC on various hardware. The hardware includes AMD64, Aarch64, PowerPC and s390x. PowerPC is a little-endian platform, and s390x is a big-endian platform. There are pairs of recipes that are similar to the following.
+
+```
+- os: linux
+  name: GCC on Linux, Aarch64
+  compiler: gcc
+  arch: arm64
+  dist: bionic
+- os: linux
+  name: Clang on Linux, Aarch64
+  compiler: clang
+  arch: arm64
+  dist: bionic
+```
+
+OS X provides a single recipe to test Clang. GCC is not tested because GCC is an alias for Clang.
+
+## Sanitizer builds
+
+Two sanitizer builds are tested using Clang and GCC, for a total of four builds. The first sanitizer is Undefined Behavior sanitizer (UBsan), and the second is Address sanitizer (Asan). The sanitizers are only run on AMD64 hardware. Note the environment includes `UBSAN=yes` or `ASAN=yes` for the sanitizer builds.
+
+The recipes are similar to the following.
+
+```
+- os: linux
+  name: UBsan, GCC on Linux, Amd64
+  compiler: gcc
+  arch: amd64
+  dist: bionic
+  env: UBSAN=yes
+- os: linux
+  name: UBsan, Clang on Linux, Amd64
+  compiler: clang
+  arch: amd64
+  dist: bionic
+  env: UBSAN=yes
+```
+
+When the Travis script encounters a sanitizer it uses different `CFLAGS` and configuration string.
+
+```
+if [ "$UBSAN" = "yes" ]; then
+  export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover"
+  bash test/test_ci.sh
+elif [ "$ASAN" = "yes" ]; then
+  export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address"
+  bash test/test_ci.sh
+...
+```
+
+## Android builds
+
+Travis tests Android builds for the armv7a, aarch64, x86 and x86_64 architectures. The builds are trickier than other builds for several reasons. The testing requires installation of the Android NDK and SDK, it requires a cross-compile, and requires OpenSSL prerequisites. The Android cross-compiles also require care to set the Autotools triplet, the OpenSSL triplet, the toolchain path, the tool variables, and the sysroot. The discussion below detail the steps of the Android recipes.
+
+### Tool installation
+
+The first step installs tools needed for OpenSSL and LDNS. This step is handled in by the script `contrib/android/install_tools.sh`, and it is run by Travis in the `before_script` in the lifecycle. The tools include curl, wget, tar, zip, unzip and java.
+
+If you are working from a developer machine you probably already have the necessary tools installed.
+
+### ANDROID_NDK_ROOT
+
+The step step for Android is to set the environmental variables `ANDROID_NDK_ROOT` and `ANDROID_SDK_ROOT`. This is an important step because the NDK and SDK use the variables internally to locate their own tools. Also see [Recommended NDK Directory?](https://groups.google.com/forum/#!topic/android-ndk/qZjhOaynHXc) on the android-ndk mailing list. (Many folks botch this step, and use incorrect variables like `ANDROID_NDK_HOME` or `ANDROID_SDK_HOME`).
+
+LDNS exports the variables in the Travis configuration script for the Android recipe:
+
+```
+export ANDROID_SDK_ROOT="$HOME/android-sdk"
+export ANDROID_NDK_ROOT="$HOME/android-ndk"
+```
+
+### NDK installation
+
+The third step installs the NDK and SDK. This step is handled in by the script `contrib/android/install_ndk.sh`. The script uses `ANDROID_NDK_ROOT` and `ANDROID_SDK_ROOT` to place the NDK and SDK in the `$HOME` directory.
+
+If you are working from a developer machine you probably already have a NDK and SDK installed.
+
+### Android environment
+
+The fourth step sets the Android cross-compile environment using the script `contrib/android/setenv_android.sh`. The script is `sourced` so the variables in the script are available to the calling shell. The script sets variables like `CC`, `CXX`, `AS` and `AR`; sets `CFLAGS` and `CXXFLAGS`; sets a `sysroot` so Android headers and libraries are found; and adds the path to the toolchain to `PATH`.
+
+`contrib/android/setenv_android.sh` knows which toolchain and architecture to select by inspecting environmental variables set by Travis for the job. In particular, the variables `ANDROID_CPU` and `ANDROID_API` tell `contrib/android/setenv_android.sh` what tools and libraries to select. For example, below is part of the Aarch64 recipe.
+
+```
+- os: linux
+  name: Android aarch64, Linux, Amd64
+  compiler: clang
+  arch: amd64
+  dist: bionic
+  env:
+    - ANDROID=yes
+    - AUTOTOOLS_HOST=aarch64-linux-android
+    - OPENSSL_HOST=android-arm64
+    - ANDROID_CPU=aarch64
+    - ANDROID_API=23
+```
+
+The `contrib/android/setenv_android.sh` script specifies the tools in a `case` statement like the following. There is a case for each of the architectures armv7a, aarch64, x86 and x86_64.
+
+```
+armv8a|aarch64|arm64|arm64-v8a)
+  CC="aarch64-linux-android$ANDROID_API-clang"
+  CXX="aarch64-linux-android$ANDROID_API-clang++"
+  LD="aarch64-linux-android-ld"
+  AS="aarch64-linux-android-as"
+  AR="aarch64-linux-android-ar"
+  RANLIB="aarch64-linux-android-ranlib"
+  STRIP="aarch64-linux-android-strip"
+
+  CFLAGS="-funwind-tables -fexceptions"
+  CXXFLAGS="-funwind-tables -fexceptions -frtti"
+```
+
+### OpenSSL
+
+The fifth step builds OpenSSL. OpenSSL are built for Android using the script `contrib/android/install_openssl.sh`. The scripts download, configure and install the latest release version of the libraries. The libraries are configured with `--prefix="$ANDROID_PREFIX"` so the headers are placed in `$ANDROID_PREFIX/include` directory, and the libraries are placed in the `$ANDROID_PREFIX/lib` directory.
+
+`ANDROID_PREFIX` is the value `$HOME/android$ANDROID_API-$ANDROID_CPU`. The libraries will be installed in `$HOME/android23-armv7a`, `$HOME/android23-aarch64`, etc. For Autotools projects, the appropriate `PKG_CONFIG_PATH` is exported. `PKG_CONFIG_PATH` is the userland equivalent to sysroot, and allows Autotools to find non-system library's headers and libraries for an architecture. Typical `PKG_CONFIG_PATH` are `$HOME/android23-armv7a/lib/pkgconfig` and `$HOME/android23-aarch64/lib/pkgconfig`.
+
+OpenSSL also uses a custom configuration file called `15-android.conf`. It is a copy of the OpenSSL's project file and located at `contrib/android/15-android.conf`. The LDNS version is copied to the OpenSSL source files after unpacking the OpenSSL distribution. The LDNS version has legacy NDK support removed and some other fixes, like `ANDROID_NDK_ROOT` awareness. The changes mean LDNS's `15-android.conf` will only work with LDNS, with NDK-r19 and above, and a properly set environment.
+
+OpenSSL is configured with `no-engine`. If you want to include OpenSSL engines then edit `contrib/android/install_openssl.sh` and remove the config option.
+
+### Android build
+
+Finally, once OpenSSL are built, then the Travis script configures and builds LDNS. The recipe looks as follows.
+
+```
+elif [ "$ANDROID" = "yes" ]; then
+  export AUTOTOOLS_BUILD="$(./config.guess)"
+  export PKG_CONFIG_PATH="$ANDROID_PREFIX/lib/pkgconfig"
+  ./contrib/android/install_ndk.sh
+  source ./contrib/android/setenv_android.sh
+  ./contrib/android/install_openssl.sh
+  ./contrib/android/bootstrap_ldns.sh
+  ./configure \
+    --build="$AUTOTOOLS_BUILD" --host="$AUTOTOOLS_HOST" \
+    --prefix="$ANDROID_PREFIX" \
+    --with-ssl="$ANDROID_PREFIX" --disable-gost \
+    --with-drill --with-examples
+  make -j 2
+  make install
+```
+
+Travis only smoke tests an Android build using a compile and link. The self tests are not run. TODO: figure out how to fire up an emulator, push the tests to the device and run them.
+
+### Android flags
+
+`contrib/android/setenv_android.sh` uses specific flags for `CFLAGS` and `CXXFLAGS`. They are taken from `ndk-build`, so we consider them the official flag set. It is important to use the same flags across projects to avoid subtle problems due to mixing and matching different flags.
+
+`CXXFLAGS` includes `-fexceptions` and `-frtti` because exceptions and runtime type info are disabled by default. `CFLAGS` include `-funwind-tables` and `-fexceptions` to ensure C++ exceptions pass through C code, if needed. Also see `docs/CPLUSPLUS-SUPPORT.html` in the NDK docs.
+
+To inspect the flags used by `ndk-build` for a platform clone ASOP's [ndk-samples](https://github.com/android/ndk-samples/tree/master/hello-jni) and build the `hello-jni` project. Use the `V=1` flag to see the full compiler output from `ndk-build`.

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_PROG_MAKE_SET
 # Extra (sp)lint flags for NetBSD
 AC_CANONICAL_HOST
 case "$host_os" in
-	netbsd*) LINTFLAGS="'-D__RENAME(x)=' -D_NETINET_IN_H_ $LINTFLAGS" 
+	netbsd*) LINTFLAGS="'-D__RENAME(x)=' -D_NETINET_IN_H_ $LINTFLAGS"
 		 ;;
 	*)       LINTFLAGS="$LINTFLAGS"
 		 ;;
@@ -143,8 +143,8 @@ AC_CHECK_FUNC([inet_pton],
 ])
 
 
-AC_ARG_WITH(drill, AC_HELP_STRING([--with-drill], 
- [Also build drill.]), 
+AC_ARG_WITH(drill, AC_HELP_STRING([--with-drill],
+ [Also build drill.]),
  [],[with_drill="no"])
 if test x_$with_drill != x_no ; then
 	AC_SUBST(DRILL,[drill])
@@ -156,7 +156,7 @@ if test x_$with_drill != x_no ; then
 		AC_MSG_ERROR([
 A config.h was detected in the drill subdirectory.
 This does not work with the --with-drill option.
-Please remove the config.h from the drill subdirectory 
+Please remove the config.h from the drill subdirectory
 or do not use the --with-drill option.])
 	fi
 else
@@ -168,8 +168,8 @@ else
 fi
 
 
-AC_ARG_WITH(examples, AC_HELP_STRING([--with-examples], 
- [Also build examples.]), 
+AC_ARG_WITH(examples, AC_HELP_STRING([--with-examples],
+ [Also build examples.]),
  [],[with_examples="no"])
 if test x_$with_examples != x_no ; then
 	AC_SUBST(EXAMPLES,[examples])
@@ -181,7 +181,7 @@ if test x_$with_examples != x_no ; then
 		AC_MSG_ERROR([
 A config.h was detected in the examples subdirectory.
 This does not work with the --with-examples option.
-Please remove the config.h from the examples subdirectory 
+Please remove the config.h from the examples subdirectory
 or do not use the --with-examples option.])
 	fi
 else
@@ -212,7 +212,7 @@ AC_ARG_ENABLE(stderr-msgs, AC_HELP_STRING([--enable-stderr-msgs], [Enable printi
 case "$enable_stderr_msgs" in
     no) dnl default
         ;;
-    *)  
+    *)
         AC_DEFINE_UNQUOTED([STDERR_MSGS], [1], [Define this to enable messages to stderr.])
         ;;
 esac
@@ -228,8 +228,8 @@ AX_CONFIG_FEATURE(
 PYTHON_X_CFLAGS=""
 ldns_with_pyldns=no
 ldns_with_pyldnsx=no
-AC_ARG_WITH(pyldns, AC_HELP_STRING([--with-pyldns], 
- [generate python library, or --without-pyldns to disable Python support.]), 
+AC_ARG_WITH(pyldns, AC_HELP_STRING([--with-pyldns],
+ [generate python library, or --without-pyldns to disable Python support.]),
  [],[ withval="no" ])
 ldns_have_python=no
 if test x_$withval != x_no; then
@@ -284,8 +284,8 @@ fi
 AC_SUBST(PYTHON_X_CFLAGS)
 
 # Check for pyldnsx
-AC_ARG_WITH(pyldnsx, AC_HELP_STRING([--without-pyldnsx], 
-  [Do not install the ldnsx python module, or --with-pyldnsx to install it.]), 
+AC_ARG_WITH(pyldnsx, AC_HELP_STRING([--without-pyldnsx],
+  [Do not install the ldnsx python module, or --with-pyldnsx to install it.]),
   [],[ withval="with_pyldns" ])
 if test x_$withval != x_no; then
   if test x_$ldns_with_pyldns != x_no; then
@@ -315,8 +315,8 @@ fi
 
 # check for perl
 ldns_with_p5_dns_ldns=no
-AC_ARG_WITH(p5-dns-ldns, AC_HELP_STRING([--with-p5-dns-ldns], 
- [generate DNS::LDNS perl bindings]), 
+AC_ARG_WITH(p5-dns-ldns, AC_HELP_STRING([--with-p5-dns-ldns],
+ [generate DNS::LDNS perl bindings]),
  [],[ withval="no" ])
 ldns_have_perl=no
 if test x_$withval != x_no; then
@@ -353,7 +353,7 @@ else
 	AC_MSG_RESULT([no])
 fi
 AC_CHECK_HEADERS([openssl/ssl.h openssl/evp.h openssl/engine.h openssl/conf.h])
-AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 ENGINE_load_cryptodev EVP_PKEY_keygen ECDSA_SIG_get0 EVP_MD_CTX_new EVP_PKEY_base_id DSA_SIG_set0 DSA_SIG_get0 EVP_dss1 DSA_get0_pqg DSA_get0_key EVP_cleanup ENGINE_cleanup ENGINE_free CRYPTO_cleanup_all_ex_data ERR_free_strings CONF_modules_unload OPENSSL_init_ssl OPENSSL_init_crypto ERR_load_crypto_strings CRYPTO_memcmp])
+AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 EVP_PKEY_keygen ECDSA_SIG_get0 EVP_MD_CTX_new EVP_PKEY_base_id DSA_SIG_set0 DSA_SIG_get0 EVP_dss1 DSA_get0_pqg DSA_get0_key EVP_cleanup ENGINE_cleanup ENGINE_free CRYPTO_cleanup_all_ex_data ERR_free_strings CONF_modules_unload OPENSSL_init_ssl OPENSSL_init_crypto ERR_load_crypto_strings CRYPTO_memcmp])
 
 # for macosx, see if glibtool exists and use that
 # BSD's need to know the version...
@@ -443,7 +443,7 @@ int load_gost_id(void)
 	EVP_PKEY_asn1_get0_info(&gost_id, NULL, NULL, NULL, NULL, meth);
 	return gost_id;
 }
-int main(void) { 
+int main(void) {
 	EVP_MD_CTX* ctx;
 	const EVP_MD* md;
 	unsigned char digest[64]; /* its a 256-bit digest, so uses 32 bytes */
@@ -613,9 +613,9 @@ case "$enable_dane" in
                   AC_SUBST(ldns_build_config_use_dane_ta_usage, 0)
                   ;;
                 *) dnl default
-      	    LIBS="-lssl $LIBS"
+                  LIBS="-lssl -lcrypto $LIBS"
                   AC_CHECK_FUNC(SSL_get0_dane, [], [AC_MSG_ERROR([OpenSSL does not support offline DANE verification (Needed for the DANE-TA usage type).  Please upgrade OpenSSL to version >= 1.1.0 or rerun with --disable-dane-verify or --disable-dane-ta-usage])])
-                  LIBSSL_LIBS="-lssl $LIBSSL_LIBS"
+                  LIBSSL_LIBS="-lssl -lcrypto"
                   AC_SUBST(ldns_build_config_use_dane_ta_usage, 1)
                   AC_DEFINE_UNQUOTED([USE_DANE_TA_USAGE], [1], [Define this to enable DANE-TA usage type support.])
                   ;;
@@ -799,7 +799,7 @@ AC_CHECK_LIB(pcap, pcap_open_offline, [
     ]
 )
 AC_CHECK_HEADERS([netinet/in_systm.h net/if.h netinet/ip.h netinet/udp.h netinet/igmp.h netinet/if_ether.h netinet/ip6.h net/ethernet.h netinet/ip_compat.h],,, [
-AC_INCLUDES_DEFAULT 
+AC_INCLUDES_DEFAULT
 #ifdef HAVE_NETINET_IN_SYSTM_H
 #include <netinet/in_systm.h>
 #endif
@@ -886,8 +886,8 @@ ACX_FUNC_IOCTLSOCKET
 ACX_CHECK_FORMAT_ATTRIBUTE
 ACX_CHECK_UNUSED_ATTRIBUTE
 
-AC_ARG_WITH(xcode-sdk, AC_HELP_STRING([--with-xcode-sdk], 
- [Set xcode SDK version. Default is autodetect]), 
+AC_ARG_WITH(xcode-sdk, AC_HELP_STRING([--with-xcode-sdk],
+ [Set xcode SDK version. Default is autodetect]),
  [],[with_xcode_sdk="yes"])
 if test "x_$with_xcode_sdk" != "x_no" ; then
    # check OSX deployment target, if needed

--- a/contrib/android/15-android.conf
+++ b/contrib/android/15-android.conf
@@ -1,0 +1,37 @@
+#### Android...
+#
+# Heavily hacked 15-android.conf based on OpenSSL's config file of the same name.
+# This 15-android.conf avoids compiler errors using NDK-r20. This 15-android.conf
+# requires an environment set (sourced) using setenv-android.sh.
+
+my %targets = (
+    "android" => {
+        inherit_from     => [ "linux-generic32" ],
+        template         => 1,
+        bin_cflags       => add("-fPIE"),
+        bin_lflags       => add("-pie"),
+        enable           => [ ],
+    },
+
+    "android-arm" => {
+        inherit_from     => [ "android", asm("armv4_asm") ],
+        bn_ops           => [ "BN_LLONG", "RC4_CHAR" ],
+    },
+    "android-arm64" => {
+        inherit_from     => [ "android", asm("aarch64_asm") ],
+        bn_ops           => [ "SIXTY_FOUR_BIT_LONG", "RC4_CHAR" ],
+        perlasm_scheme   => "linux64",
+    },
+
+    "android-x86" => {
+        inherit_from     => [ "android", asm("x86_asm") ],
+        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        bn_ops           => [ "BN_LLONG", "RC4_INT" ],
+        perlasm_scheme   => "android",
+    },
+    "android-x86_64" => {
+        inherit_from     => [ "android", asm("x86_64_asm") ],
+        bn_ops           => [ "SIXTY_FOUR_BIT_LONG", "RC4_INT" ],
+        perlasm_scheme   => "elf",
+    },
+);

--- a/contrib/android/bootstrap_ldns.sh
+++ b/contrib/android/bootstrap_ldns.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+if ! git submodule update --init; then
+    echo "Failed to init submodule"
+    exit 1
+fi
+
+echo "AUTOTOOLS_BUILD: $AUTOTOOLS_BUILD"
+echo "AUTOTOOLS_HOST:  $AUTOTOOLS_HOST"
+
+# libtool complains about our updated config.guess and config.sub.
+# Remove them to get through bootstrap. Re-add them after libtoolize.
+
+echo "Running libtoolize"
+if [ -n "$(command -v glibtoolize)" ]; then
+    rm -f config.guess config.sub
+    if ! glibtool -ci ; then
+        echo "Failed to libtoolize (glibtoolize)"
+        exit 1
+    fi
+elif [ -n "$(command -v libtoolize)" ]; then
+    rm -f config.guess config.sub
+    if ! libtoolize -ci ; then
+        echo "Failed to libtoolize (libtoolize)"
+        exit 1
+    fi
+else
+    echo "Failed to find a libtool"
+    exit 1
+fi
+
+echo "Updating config.guess"
+if ! wget -q -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'; then
+    echo "Failed to download config.guess"
+fi
+
+echo "Updating config.sub"
+if ! wget -q -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'; then
+    echo "Failed to download config.sub"
+fi
+
+echo "Fixing config permissions"
+chmod a+x config.guess config.sub
+if [ -n "$(command -v xattr 2>/dev/null)" ]; then
+    xattr -d com.apple.quarantine config.guess 2>/dev/null
+    xattr -d com.apple.quarantine config.sub 2>/dev/null
+fi
+
+echo "Running autoreconf"
+if ! autoreconf -fi ; then
+    echo "Failed to autoreconf"
+    exit 1
+fi
+
+exit 0

--- a/contrib/android/install_ndk.sh
+++ b/contrib/android/install_ndk.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+if [ -z "$ANDROID_SDK_ROOT" ]; then
+    echo "ERROR: ANDROID_SDK_ROOT is not set. Please set it."
+    echo "SDK root is $ANDROID_SDK_ROOT"
+    exit 1
+fi
+
+if [ -z "$ANDROID_NDK_ROOT" ]; then
+    echo "ERROR: ANDROID_NDK_ROOT is not set. Please set it."
+    echo "NDK root is $ANDROID_NDK_ROOT"
+    exit 1
+fi
+
+echo "Using ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
+echo "Using ANDROID_NDK_ROOT: $ANDROID_NDK_ROOT"
+
+echo "Downloading SDK"
+if ! curl -L -k -s -o "$HOME/android-sdk.zip" https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip;
+then
+    echo "Failed to download SDK"
+    exit 1
+fi
+
+echo "Downloading NDK"
+if ! curl -L -k -s -o "$HOME/android-ndk.zip" https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip;
+then
+    echo "Failed to download NDK"
+    exit 1
+fi
+
+echo "Unpacking SDK to $ANDROID_SDK_ROOT"
+if ! unzip -qq "$HOME/android-sdk.zip" -d "$ANDROID_SDK_ROOT";
+then
+    echo "Failed to unpack SDK"
+    exit 1
+fi
+
+echo "Unpacking NDK to $ANDROID_NDK_ROOT"
+if ! unzip -qq "$HOME/android-ndk.zip" -d "$HOME";
+then
+    echo "Failed to unpack NDK"
+    exit 1
+fi
+
+if ! mv "$HOME/android-ndk-r20b" "$ANDROID_NDK_ROOT";
+then
+    echo "Failed to move $HOME/android-ndk-r20b to $ANDROID_NDK_ROOT"
+    exit 1
+fi
+
+rm -f "$HOME/android-sdk.zip"
+rm -f "$HOME/android-ndk.zip"
+
+# https://stackoverflow.com/a/47028911/608639
+touch "$ANDROID_SDK_ROOT/repositories.cfg"
+
+echo "Finished installing SDK and NDK"
+
+exit 0

--- a/contrib/android/install_openssl.sh
+++ b/contrib/android/install_openssl.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+echo "Downloading OpenSSL"
+if ! curl -L -k -s -o openssl-1.1.1d.tar.gz https://www.openssl.org/source/openssl-1.1.1d.tar.gz;
+then
+    echo "Failed to download OpenSSL"
+    exit 1
+fi
+
+echo "Unpacking OpenSSL"
+rm -rf ./openssl-1.1.1d
+if ! tar -xf openssl-1.1.1d.tar.gz;
+then
+    echo "Failed to unpack OpenSSL"
+    exit 1
+fi
+
+cd openssl-1.1.1d || exit 1
+
+if ! cp ../contrib/android/15-android.conf Configurations/; then
+    echo "Failed to copy OpenSSL Android config"
+    exit 1
+fi
+
+echo "Configuring OpenSSL"
+if ! ./Configure "$OPENSSL_HOST" no-comp no-asm no-hw no-engine shared \
+       --prefix="$ANDROID_PREFIX" --openssldir="$ANDROID_PREFIX"; then
+    echo "Failed to configure OpenSSL"
+    exit 1
+fi
+
+echo "Building OpenSSL"
+if ! make; then
+    echo "Failed to build OpenSSL"
+    exit 1
+fi
+
+echo "Installing OpenSSL"
+if ! make install_sw; then
+    echo "Failed to install OpenSSL"
+    exit 1
+fi
+
+exit 0

--- a/contrib/android/install_tools.sh
+++ b/contrib/android/install_tools.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This step should install tools needed for all packages - OpenSSL and Unbound
+echo "Updating tools"
+sudo apt-get -qq update
+sudo apt-get -qq install --no-install-recommends curl wget tar zip unzip perl openjdk-8-jdk autoconf automake libtool pkg-config
+
+# Android builds run config.guess early to determine BUILD and HOST. We need to add config.guess
+# and config.sub now. Later, bootstrap_ldns.sh will handle the complete bootrap of LDNS.
+
+echo "Adding config.guess"
+if ! wget -q -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'; then
+    echo "Failed to download config.guess"
+fi
+
+echo "Adding config.sub"
+if ! wget -q -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'; then
+    echo "Failed to download config.sub"
+fi
+
+echo "Fixing config permissions"
+chmod a+x config.guess config.sub
+if [ -n "$(command -v xattr 2>/dev/null)" ]; then
+    xattr -d com.apple.quarantine config.guess 2>/dev/null
+    xattr -d com.apple.quarantine config.sub 2>/dev/null
+fi

--- a/contrib/android/setenv_android.sh
+++ b/contrib/android/setenv_android.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+# Error checking
+if [ ! -d "$ANDROID_NDK_ROOT" ]; then
+    echo "ERROR: ANDROID_NDK_ROOT is not a valid path. Please set it."
+    echo "NDK root is $ANDROID_NDK_ROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+# Need to set THIS_HOST to darwin-x86_64, linux-x86_64,
+# windows-x86_64 or windows.
+
+if [[ "$(uname -s | grep -i -c darwin)" -ne 0 ]]; then
+    THIS_HOST=darwin-x86_64
+elif [[ "$(uname -s | grep -i -c linux)" -ne 0 ]]; then
+    THIS_HOST=linux-x86_64
+else
+    echo "ERROR: Unknown host"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+AOSP_TOOLCHAIN_ROOT="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST"
+AOSP_TOOLCHAIN_PATH="$AOSP_TOOLCHAIN_ROOT/bin"
+AOSP_SYSROOT="$AOSP_TOOLCHAIN_ROOT/sysroot"
+
+# Error checking
+if [ ! -d "$AOSP_TOOLCHAIN_ROOT" ]; then
+    echo "ERROR: AOSP_TOOLCHAIN_ROOT is not a valid path. Please set it."
+    echo "Root is $AOSP_TOOLCHAIN_ROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -d "$AOSP_TOOLCHAIN_PATH" ]; then
+    echo "ERROR: AOSP_TOOLCHAIN_PATH is not a valid path. Please set it."
+    echo "Path is $AOSP_TOOLCHAIN_PATH"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -d "$AOSP_SYSROOT" ]; then
+    echo "ERROR: AOSP_SYSROOT is not a valid path. Please set it."
+    echo "Path is $AOSP_SYSROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+AOSP_CPU=$(tr '[:upper:]' '[:lower:]' <<< "$ANDROID_CPU")
+
+# https://developer.android.com/ndk/guides/abis.html
+case "$AOSP_CPU" in
+  armeabi|armv7a|armv7-a|armeabi-v7a)
+    CC="armv7a-linux-androideabi$ANDROID_API-clang"
+    CXX="armv7a-linux-androideabi$ANDROID_API-clang++"
+    LD="arm-linux-androideabi-ld"
+    AS="arm-linux-androideabi-as"
+    AR="arm-linux-androideabi-ar"
+    RANLIB="arm-linux-androideabi-ranlib"
+    STRIP="arm-linux-androideabi-strip"
+
+    CFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions"
+    CXXFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions -frtti"
+    ;;
+
+  armv8|armv8a|aarch64|arm64|arm64-v8a)
+    CC="aarch64-linux-android$ANDROID_API-clang"
+    CXX="aarch64-linux-android$ANDROID_API-clang++"
+    LD="aarch64-linux-android-ld"
+    AS="aarch64-linux-android-as"
+    AR="aarch64-linux-android-ar"
+    RANLIB="aarch64-linux-android-ranlib"
+    STRIP="aarch64-linux-android-strip"
+
+    CFLAGS="-funwind-tables -fexceptions"
+    CXXFLAGS="-funwind-tables -fexceptions -frtti"
+    ;;
+
+  x86)
+    CC="i686-linux-android$ANDROID_API-clang"
+    CXX="i686-linux-android$ANDROID_API-clang++"
+    LD="i686-linux-android-ld"
+    AS="i686-linux-android-as"
+    AR="i686-linux-android-ar"
+    RANLIB="i686-linux-android-ranlib"
+    STRIP="i686-linux-android-strip"
+
+    CFLAGS="-mtune=intel -mssse3 -mfpmath=sse -funwind-tables -fexceptions"
+    CXXFLAGS="-mtune=intel -mssse3 -mfpmath=sse -funwind-tables -fexceptions -frtti"
+    ;;
+
+  x86_64|x64)
+    CC="x86_64-linux-android$ANDROID_API-clang"
+    CXX="x86_64-linux-android$ANDROID_API-clang++"
+    LD="x86_64-linux-android-ld"
+    AS="x86_64-linux-android-as"
+    AR="x86_64-linux-android-ar"
+    RANLIB="x86_64-linux-android-ranlib"
+    STRIP="x86_64-linux-android-strip"
+
+    CFLAGS="-march=x86-64 -msse4.2 -mpopcnt -mtune=intel -funwind-tables -fexceptions"
+    CXXFLAGS="-march=x86-64 -msse4.2 -mpopcnt -mtune=intel -funwind-tables -fexceptions -frtti"
+    ;;
+
+  *)
+    echo "ERROR: Unknown architecture $ANDROID_CPU"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+    ;;
+
+esac
+
+#####################################################################
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$CC" ]; then
+    echo "ERROR: Failed to find Android clang. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$CXX" ]; then
+    echo "ERROR: Failed to find Android clang++. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$RANLIB" ]; then
+    echo "ERROR: Failed to find Android ranlib. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$AR" ]; then
+    echo "ERROR: Failed to find Android ar. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$AS" ]; then
+    echo "ERROR: Failed to find Android as. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$LD" ]; then
+    echo "ERROR: Failed to find Android ld. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+LENGTH=${#AOSP_TOOLCHAIN_PATH}
+SUBSTR=${PATH:0:$LENGTH}
+if [ "$SUBSTR" != "$AOSP_TOOLCHAIN_PATH" ]; then
+    export PATH="$AOSP_TOOLCHAIN_PATH:$PATH"
+fi
+
+#####################################################################
+
+export CPP CC CXX LD AS AR RANLIB STRIP
+export ANDROID_SYSROOT="$AOSP_SYSROOT"
+export CPPFLAGS="-D__ANDROID_API__=$ANDROID_API"
+export CFLAGS="$CFLAGS --sysroot=$AOSP_SYSROOT"
+export CXXFLAGS="$CXXFLAGS --sysroot=$AOSP_SYSROOT"
+
+#####################################################################
+
+echo "AOSP_TOOLCHAIN_PATH: $AOSP_TOOLCHAIN_PATH"
+
+echo "CC: $(command -v "$CC")"
+echo "CXX: $(command -v "$CXX")"
+echo "LD: $(command -v "$LD")"
+echo "AS: $(command -v "$AS")"
+echo "AR: $(command -v "$AR")"
+
+echo "ANDROID_SYSROOT: $ANDROID_SYSROOT"
+
+echo "CPPFLAGS: $CPPFLAGS"
+echo "CFLAGS: $CFLAGS"
+echo "CXXFLAGS: $CXXFLAGS"
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && exit 0 || return 0

--- a/test/60-compile-builddir.tpkg/60-compile-builddir.test
+++ b/test/60-compile-builddir.tpkg/60-compile-builddir.test
@@ -28,7 +28,37 @@ if [ ! $mk ] || [ ! $conf ] || [ ! $loot ] ; then
 	exit 1
 fi;
 
+# Only run this test when OpenSSL >= 1.1.0. Use objdump or nm to
+# inspect import symbols in libldns.so. nm works on semi-modern OS X.
+# otool is OS X disassembler. dis is the Solaris disassembler.
+OPENSSL_DANE_ENABLE=0
+LDNS_SHARED_OBJ=".libs/libldns.so"
+
+if [ `uname -s 2>&1 | grep -i -c Darwin` -ne 0 ]; then
+    LDNS_SHARED_OBJ=".libs/libldns.dylib"
+fi
+
+if [ ! -f "$LDNS_SHARED_OBJ" ]; then
+    echo "Failed to find $LDNS_SHARED_OBJ. Skipping test. Marking as success."
+    exit 0
+fi
+
+if [ x`command -v objdump 2>/dev/null` != "x" ]; then
+    OPENSSL_DANE_ENABLE=`objdump -T "$LDNS_SHARED_OBJ" 2>&1 | grep -i -c SSL_dane_enable`
+elif [ x`command -v nm 2>/dev/null` != "x" ]; then
+    OPENSSL_DANE_ENABLE=`nm -g -u "$LDNS_SHARED_OBJ" 2>&1 | grep -i -c SSL_dane_enable`
+elif [ x`command -v otool 2>/dev/null` != "x" ]; then
+    OPENSSL_DANE_ENABLE=`otool -tv "$LDNS_SHARED_OBJ" 2>&1 | grep -i -c SSL_dane_enable`
+elif [ x`command -v dis 2>/dev/null` != "x" ]; then
+    OPENSSL_DANE_ENABLE=`dis "$LDNS_SHARED_OBJ" 2>&1 | grep -i -c SSL_dane_enable`
+fi
+
+if [ "$OPENSSL_DANE_ENABLE" -eq 0 ]; then
+    echo "OpenSSL is too old. Skipping test. Marking as success."
+    exit 0
+fi
+
 make realclean || true
-$loot && $conf && mkdir -p b && cd b && \
-	../configure CFLAGS="-Werror=implicit-function-declaration  -DOPENSSL_API_COMPAT=0x10100000L" --with-drill --with-examples --disable-gost --disable-dane-verify --disable-dane-ta-usage && \
+$loot && $conf && mkdir -p builddir && cd builddir && \
+	../configure CFLAGS="-Werror=implicit-function-declaration -DOPENSSL_API_COMPAT=0x10100000L" --with-drill --with-examples --disable-gost && \
 	$mk


### PR DESCRIPTION
This PR adds Android testing to Travis. Take two...

There were two major campaigns in this PR. First was the obvious Android scripts and Travis tests. The Android gear was placed in `contrib/android/`. The Travis recipes calls the scripts, and eventually builds and installs LDNS.

The second campaign was a little more subtle. It required subtle fixes to `configure.ac`, `Makefile.in` and `60-compile-builddir.test`.

First, the `configure.ac` used the pair `-lssl` and `-lcrypto` for `LIBSSL_LIBS`. The fact of the matter is, anywhere you use `-lssl`, you need `-lcrypto`. They are a matched set because `-lssl` depends upon `-lcrypto`. They cannot be disgorged.

`ENGINE_load_cryptodev` was also removed from `configure.ac`. LDNS does not use it, and the OpenBSD folks are removing it from their distribution.

Second, `Makefile.in` needed some tweaks. The first tweak was a recipe to build `*.o` files using libtool so `PKG_CONFIG_PATH` was used during compilation. Without the libtool compile, the cross-compiled libraries and header files were missing.

```
.c.o:
	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $< -o $@
```

The second `Makefile.in` tweak was the ordering of libraries, and sometimes adding a missing `$(LIBSSL_LIBS)`. A typical recipe now looks like the following due to single pass linkers. Below are a couple of examples.

```
drill/drill: $(DRILL_LOBJS) $(LIB) $(LIBLOBJS)
-    $(LINK_EXE) $(DRILL_LOBJS) $(LIBLOBJS) $(LIBS) $(LIBSSL_LIBS) -lldns -o drill/drill
+    $(LINK_EXE) $(DRILL_LOBJS) $(LIBLOBJS) -lldns $(LIBSSL_LIBS) $(LIBS) -o drill/drill
```

And:

```
linktest: $(srcdir)/linktest.c libldns.la
    $(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $(srcdir)/linktest.c -o linktest.lo
-    $(LINK_EXE) linktest.lo $(LIBS) $(LIBSSL_LIBS) -lldns -o linktest
+    $(LINK_EXE) linktest.lo -lldns $(LIBSSL_LIBS) $(LIBS) -o linktest
```
The change to `60-compile-builddir.test` simply tests if OpenSSL 1.1.0 is available, and only tests the build if OpenSSL 1.1.0 is present. The OpenSSL 1.1.0 check is a necessary precondition because of `-DOPENSSL_API_COMPAT=0x10100000L` in the `CFLAGS`.

The OpenSSL 1.1.0 check is accomplished by looking for the symbol `SSL_dane_enable` in `.libs/libldns.so`. If `libldns.so` imports `SSL_dane_enable`, then Autotools determined it was available in OpenSSL.

Checking for OpenSSL 1.1.0 also allowed us to drop `--disable-dane-verify` and `--disable-dane-ta-usage`. Both need OpenSSL 1.1.0, so we know we can build the components.

`configure.ac` and `Makefile.in` also had trailing whitespace trimmed using this sed. It is an old habit of mine.

```
sed -i -e's/[[:space:]]*$//' Makefile.in configure.ac
```