### PR TITLE
Fix Brew update and install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ addons:
       - indent
   homebrew:
     packages:
-      - gnu-indent
-      - doxygen
       - openssl
-      - indent
+      - doxygen
+      - findent
+    update: true
 
 jobs:
   include:


### PR DESCRIPTION
Both `brew update` and the `install` recipe was producing errors.

The `indent` package under Brew is called `findent`.

Also see:

* [OS X image and “Error: Unknown command: bundle”](https://travis-ci.community/t/os-x-image-and-error-unknown-command-bundle/7493/2) (Travis Message Boards)
* [Travis | Installing Dependencies](https://docs.travis-ci.com/user/installing-dependencies/) (Travis docs)