### PR TITLE
Fix Travis failures due to Homebrew

### DIFF
--- a/contrib/ios/install_tools.sh
+++ b/contrib/ios/install_tools.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # This step should install tools needed for all packages - OpenSSL and LDNS
+# When running on Travis, Homebrew fails in unusual ways, hence '|| true'.
+# https://travis-ci.community/t/homebrew-fails-because-an-automake-update-is-an-error/7831/3
 echo "Updating tools"
-brew update 1>/dev/null
+brew update 1>/dev/null || true
 echo "Installing tools"
-brew install autoconf automake libtool pkg-config curl perl 1>/dev/null
+brew install autoconf automake libtool pkg-config curl perl 1>/dev/null || true


### PR DESCRIPTION
This PR fixes Travis failures due to Homebrew.

Also see [Homebrew fails because an automake update is an error?](https://travis-ci.community/t/homebrew-fails-because-an-automake-update-is-an-error/7831/3) on the Travis Community message boards. According to the Travis folks `brew update` can fail if there are no updates. And `brew install` can fail if there's an update available. The simplest way to cover all the bases is to return `true` under all conditions.

Returning `true` for some conditions is incorrect, like a network error. However, we need to get through `brew update` and `brew install`, which is the common case.