### PR TITLE
Provide an API to generate wire buffers without compressed domain names

### DIFF
--- a/ldns/host2wire.h
+++ b/ldns/host2wire.h
@@ -147,6 +147,15 @@ ldns_status ldns_rr_rdata2buffer_wire(ldns_buffer *output, const ldns_rr *rr);
 ldns_status ldns_pkt2buffer_wire(ldns_buffer *output, const ldns_pkt *pkt);
 
 /**
+ * Copies the packet data to the buffer in wire format
+ * \param[out] *output buffer to append the result to
+ * \param[in] *pkt packet to convert
+ * \param[out] *compression_data data structure holding state for compression
+ * \return ldns_status
+ */
+ldns_status ldns_pkt2buffer_wire_compress(ldns_buffer *output, const ldns_pkt *pkt, ldns_rbtree_t *compression_data);
+
+/**
  * Copies the rr_list data to the buffer in wire format
  * \param[out] *output buffer to append the result to
  * \param[in] *rrlist rr_list to to convert


### PR DESCRIPTION
I'm using ldns in a project, but have a need for some specific requests to be generated without domain name compression. Right now there's no easy way to do that as the compression logic in `ldns_pkt2wire` is unconditional. Adding an `ldns_pkt2buffer_wire_compress` function that I can explicitly call with a NULL rbtree seems like the easiest, least invasive way to add this functionality, and fits with the existing API.

What are your thoughts? Is this functionality you'd like to support in ldns, and if so does this approach seem okay?