### PR TITLE
Move python libraries to separate options in ldns-config

### DIFF
--- a/packaging/ldns-config.in
+++ b/packaging/ldns-config.in
@@ -4,12 +4,15 @@ prefix="@prefix@"
 exec_prefix="@exec_prefix@"
 VERSION="@PACKAGE_VERSION@"
 CFLAGS="@CFLAGS@"
-CPPFLAGS="@CPPFLAGS@ @LIBSSL_CPPFLAGS@ @PYTHON_CPPFLAGS@"
-LDFLAGS="@LDFLAGS@ @LIBSSL_LDFLAGS@ @PYTHON_LDFLAGS@"
+CPPFLAGS="@CPPFLAGS@ @LIBSSL_CPPFLAGS@"
+LDFLAGS="@LDFLAGS@ @LIBSSL_LDFLAGS@"
+PYTHON_CPPFLAGS="@PYTHON_CPPFLAGS@"
+PYTHON_LDFLAGS="@PYTHON_LDFLAGS@"
 LIBS="@LIBS@ @LIBSSL_LIBS@"
 LIBDIR="@libdir@"
 INCLUDEDIR="@includedir@"
 LIBVERSION="@VERSION_INFO@"
+
 
 for arg in $@
 do
@@ -17,13 +20,21 @@ do
     then
         echo "-I${INCLUDEDIR}"
     fi
+    if [ $arg = "--python-cflags" ]
+    then
+        echo "${PYTHON_CPPFLAGS} -I${INCLUDEDIR}"
+    fi
     if [ $arg = "--libs" ]
     then
         echo "${LDFLAGS} -L${LIBDIR} ${LIBS} -lldns"
     fi
+    if [ $arg = "--python-libs" ]
+    then
+        echo "${LDFLAGS} ${PYTHON_LDFLAGS} -L${LIBDIR} ${LIBS} -lldns"
+    fi
     if [ $arg = "-h" ] || [ $arg = "--help" ]
     then
-        echo "Usage: $0 [--cflags] [--libs] [--version]"
+        echo "Usage: $0 [--cflags] [--python-cflags] [--libs] [--python-libs] [--version]"
     fi
     if [ $arg = "--version" ]
     then


### PR DESCRIPTION
Libraries provided by ldns-config --libs differs from pkg-config --libs
ldns, when python compilation is enabled. It may bring undesired
dependencies to consuming software. Openssh is good example.

Move python libraries to --python-libs, in case it is required. Common
C build do not require python libraries at all.