### PR TITLE
draft-ietf-dnsop-nsec-ttl-01 NSEC TTLs with signing

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -17,7 +17,9 @@
 	  if they arrive within 100msec of each other.
 	* Fix so that ldns-testns does not leak sockets if the read fails.
 	* SVCB and HTTPS draft rrtypes.
-	  Enable with --enable-rrtype-svcb-https
+	  Enable with --enable-rrtype-svcb-https.
+	* bugfix #117: Assertion failure with DNSSEC validating of 
+	  non existence of RR types at the root.  Thanks ZjYwMj
 
 1.7.1	2019-07-26
 	* bugfix: Manage verification paths for OpenSSL >= 1.1.0

--- a/Changelog
+++ b/Changelog
@@ -16,6 +16,8 @@
 	* ldns-testns can answer several queries over one tcp connection,
 	  if they arrive within 100msec of each other.
 	* Fix so that ldns-testns does not leak sockets if the read fails.
+	* SVCB and HTTPS draft rrtypes.
+	  Enable with --enable-rrtype-svcb-https
 
 1.7.1	2019-07-26
 	* bugfix: Manage verification paths for OpenSSL >= 1.1.0

--- a/rr.c
+++ b/rr.c
@@ -2235,7 +2235,7 @@ static ldns_rr_descriptor rdata_field_descriptors[] = {
 	/* 64 */
 	{LDNS_RR_TYPE_SVCB, "SVCB", 2, 3, type_svcb_wireformat, LDNS_RDF_TYPE_NONE, LDNS_RR_NO_COMPRESS, 0 },
 	/* 65 */
-	{LDNS_RR_TYPE_HTTPS, "HTTPS", 1, 1, type_svcb_wireformat, LDNS_RDF_TYPE_NONE, LDNS_RR_NO_COMPRESS, 0 },
+	{LDNS_RR_TYPE_HTTPS, "HTTPS", 2, 3, type_svcb_wireformat, LDNS_RDF_TYPE_NONE, LDNS_RR_NO_COMPRESS, 0 },
 
 #else
 {LDNS_RR_TYPE_NULL, "TYPE64", 1, 1, type_0_wireformat, LDNS_RDF_TYPE_NONE, LDNS_RR_NO_COMPRESS, 0 },


### PR DESCRIPTION
The TTL value for any NSEC RR SHOULD be the same TTL value as the lesser of the MINIMUM field of the SOA record and the TTL of the SOA itself. This matches the definition of the TTL for negative responses in [RFC2308].

Edit see: https://datatracker.ietf.org/doc/draft-ietf-dnsop-nsec-ttl/
Implementation status on: https://trac.ietf.org/trac/dnsop/wiki/draft-ietf-dnsop-nsec-ttl