### PR TITLE
fix ldns.pc installation when building out-of-source

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -397,7 +397,7 @@ packaging/libldns.pc: $(srcdir)/packaging/libldns.pc.in
 	./config.status --file=$@
 
 install-pc: packaging/libldns.pc
-	$(INSTALL) -m 644 packaging/libldns.pc $(DESTDIR)$(libdir)/pkgconfig/ldns.pc
+	$(INSTALL) -m 644 $(srcdir)/packaging/libldns.pc $(DESTDIR)$(libdir)/pkgconfig/ldns.pc
 
 uninstall-pc:
 	$(LIBTOOL) --mode=uninstall rm -f $(DESTDIR)$(libdir)/pkgconfig/ldns.pc


### PR DESCRIPTION
If ldns is built from a directory which is different from the source directory, the installation will fail as libldns.pc is searched in a wrong path.

This PR fixes the problem.

Reproducer:
```
cd ldns
mkdir build
cd build
../configure
make
make install
```