### PR TITLE
use pkg-config for OpenSSL configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -348,14 +348,37 @@ tmp_CPPFLAGS=$CPPFLAGS
 tmp_LDFLAGS=$LDFLAGS
 tmp_LIBS=$LIBS
 
-ACX_WITH_SSL_OPTIONAL
-AC_MSG_CHECKING([for LibreSSL])
-if grep VERSION_TEXT $ssldir/include/openssl/opensslv.h | grep "LibreSSL" >/dev/null; then
-	AC_MSG_RESULT([yes])
-	AC_DEFINE([HAVE_LIBRESSL], [1], [Define if we have LibreSSL])
-else
-	AC_MSG_RESULT([no])
+PKG_WITH_MODULES([openssl], [openssl], [
+    # used later for compilation
+    LIBSSL_CPPFLAGS="$openssl_CFLAGS"
+    LIBSSL_LDFLAGS="$openssl_LIBS"
+    LIBSSL_LIBS="$openssl_LIBS"
+    LIBSSL_SSL_LIBS="$openssl_LIBS"
+
+    # used for feature detection and will be reverted
+    CPPFLAGS="$CPPFLAGS $openssl_CFLAGS"
+    LDFLAGS="$LDFLAGS $openssl_LIBS"
+    LIBS="$LIBS $openssl_LIBS"
+
+    HAVE_SSL=yes
+    AC_DEFINE_UNQUOTED([HAVE_SSL], [], [Define if SSL available])
+    AC_SUBST(HAVE_SSL)
+])
+
+if test "$HAVE_SSL" = yes; then
+    PKG_CHECK_VAR([ssldir], [openssl], [prefix])
+
+    AC_MSG_CHECKING([for LibreSSL])
+    if grep VERSION_TEXT $ssldir/include/openssl/opensslv.h | grep "LibreSSL" >/dev/null; then
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_LIBRESSL], [1], [Define if we have LibreSSL])
+    else
+        AC_MSG_RESULT([no])
+    fi
 fi
+
+AC_SUBST(RUNTIME_PATH)
+
 AC_CHECK_HEADERS([openssl/ssl.h openssl/evp.h openssl/engine.h openssl/conf.h])
 AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 EVP_PKEY_keygen ECDSA_SIG_get0 EVP_MD_CTX_new EVP_PKEY_base_id DSA_SIG_set0 DSA_SIG_get0 EVP_dss1 DSA_get0_pqg DSA_get0_key EVP_cleanup ENGINE_cleanup ENGINE_free CRYPTO_cleanup_all_ex_data ERR_free_strings CONF_modules_unload OPENSSL_init_ssl OPENSSL_init_crypto ERR_load_crypto_strings CRYPTO_memcmp])
 


### PR DESCRIPTION
This is a proposal to switch OpenSSL build configuration to pkgconfig.

I'm trying to get ldns to build with [Conan](conan.io) and also get it into the official package registry. However, my package doesn't build in all configurations. There are some cases where custom code to detect OpenSSL doesn't work. For instance, when OpenSSL is linked statically, it requires a few extra static libraries to be linked (`pthread` and `rt`) and while I see some detection for that in `acx_nlnetlabs.m4` it doesn't seem to work always.

In case pkg-config is not available, the implementation allows specifying the OpenSSL configuration manually:

```
$ ./configure --help
...
Some influential environment variables:
...
  PKG_CONFIG  path to pkg-config utility
  PKG_CONFIG_PATH
              directories to add to pkg-config's search path
  PKG_CONFIG_LIBDIR
              path overriding pkg-config's built-in search path
  openssl_CFLAGS
              C compiler flags for openssl, overriding pkg-config
  openssl_LIBS
              linker flags for openssl, overriding pkg-config
  ssldir      value of prefix for openssl, overriding pkg-config
...
```

Please, let me know what you think.