### PR TITLE
ldns-verify-zone: report ZONEMD errors correctly

### DIFF
--- a/examples/ldns-verify-zone.c
+++ b/examples/ldns-verify-zone.c
@@ -939,7 +939,7 @@ main(int argc, char **argv)
 		
 		if (zonemd_result)
 			fprintf( myerr, "Could not validate zone digest: %s\n"
-			       , ldns_get_errorstr_by_id(result));
+			       , ldns_get_errorstr_by_id(zonemd_result));
 
 		else if (verbosity > 3)
 			fprintf( myout


### PR DESCRIPTION
Instead of reporting whatever `result` was set to from earlier.