### PR TITLE
Call ldns_dname2canonical for RDATA of NSEC and NSEC3 records

### DIFF
--- a/rr.c
+++ b/rr.c
@@ -1797,6 +1797,8 @@ ldns_rr2canonical(ldns_rr *rr)
         	case LDNS_RR_TYPE_DNAME:
         	case LDNS_RR_TYPE_A6:
         	case LDNS_RR_TYPE_RRSIG:
+        	case LDNS_RR_TYPE_NSEC:
+        	case LDNS_RR_TYPE_NSEC3:
 			for (i = 0; i < ldns_rr_rd_count(rr); i++) {
 				ldns_dname2canonical(ldns_rr_rdf(rr, i));
 			}


### PR DESCRIPTION
Interoperability testing of zone digests revealed a corner case where ldns was not properly canonicalizing NSEC records.  According to Section 6.2 of RFC 4034, NSEC records are included in the list of those that should have uppercase US-ASCII letters replaced with the corresponding lowercase ones for DNS names in their RDATA.  Not doing so in ldns will cause it to generate an incorrect digest or fail to validate a ZONEMD for a zone that uses NSEC records and has names with uppercase characters.

NSEC3 records potentially have the same issue.  These are machine generated and are unlikely to contain uppercase characters, but I believe it is technically legal to do so.  Just in case, I think it makes sense to also canonicalize these.