### PR TITLE
Remove undefined status variable from exception

### DIFF
--- a/contrib/python/ldns_rdf.i
+++ b/contrib/python/ldns_rdf.i
@@ -315,8 +315,7 @@ specified in the (16-bit) type field with a value from ldns_rdf_type."
             """
             rr = _ldns.ldns_rdf_new_frm_str(rr_type, string)
             if (not rr) and raiseException:
-                raise Exception("Can't create query packet, " +
-                    "error: %d" % status)
+                raise Exception("Can't create query packet"))
             return rr
 
         #


### PR DESCRIPTION
Triggered by:
ldns.ldns_rdf.new_frm_str("::1", ldns.LDNS_RDF_TYPE_A)