### PR TITLE
Revert "spelling: distclean"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -350,7 +350,7 @@ install: install-h install-lib install-pc @INSTALL_CONFIG@ install-manpages $(py
 
 uninstall: uninstall-manpages @UNINSTALL_CONFIG@ uninstall-h uninstall-lib uninstall-pc $(pyldns_uninst) $(pyldnsx_uninst) @UNINSTALL_P5_DNS_LDNS@ @UNINSTALL_DRILL@ @UNINSTALL_EXAMPLES@
 
-distclean: uninstall
+destclean: uninstall
 
 install-config:
 	$(INSTALL) -d $(DESTDIR)$(bindir)


### PR DESCRIPTION
"distclean" is a *different* kind of target than "destclean"

"destclean" presumably means "uninstall from the destination".

"distclean" means, by convention, "clean the source into the way that
you would like before creating a tarball for distribution"

This switch introduced some ugliness for debian packaging, as can be
seen in
https://salsa.debian.org/dns-team/ldns/-/commit/8b84b73590ac4321e1bf0982d60a7e94b037d6e5

This reverts commit 298b2a65920944aee833d4392e3651f25421c759.