### PR TITLE
non-substantive: spelling cleanup

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -55,7 +55,7 @@
 	  Thanks Felipe Gasper
 	* PR #126: Link with libldns.la in Makefile.in.
 	  Thanks orbea
-	* PR #127: Addes option -Q to drill to give short answer.
+	* PR #127: Added option -Q to drill to give short answer.
 	  Thanks niknah
 	* PR #133: Update m4 files for python modules.
 	  Thanks Petr Menšík
@@ -243,7 +243,7 @@
 	  Thanks William King
 	* Use OpenSSL DANE functions for verification (unless explicitly
 	  disabled with --disable-dane-ta-usage).
-	* Bumb .so version
+	* Bump .so version
 	* Include OPENPGPKEY RR type by default
 	* rdata processing for SMIMEA RR type
 	* Fix crash in displaying TLSA RR's.
@@ -313,7 +313,7 @@
 	* bugfix #505: Manpage and usage output fixes (Thanks Tomas Hozza)
 	* Adjust ldns_sha1() so that the input data is not modified (Thanks
 	  Marc Buijsman)
-	* Messages to stderr are now off by default and can be reenabled with
+	* Messages to stderr are now off by default and can be re-enabled with
 	  the --enable-stderr-msgs configure option.
 
 1.6.16	2012-11-13
@@ -656,7 +656,7 @@
 	* --enable-gost : use the GOST algorithm (experimental).
 	* Added some missing options to drill manpage
 	* Some fixes to --without-ssl option
-	* Fixed quote parsing withing strings
+	* Fixed quote parsing within strings
 	* Bitmask fix in EDNS handling
 	* Fixed non-fqdn domain name completion for rdata field domain
 	  names of length 1
@@ -945,7 +945,7 @@
 	* -r was killed in favor of -o <header bit mnemonic> which
 	  allows for a header bits setting (and maybe more in the
 	  future)
-	* DNSSEC is never automaticaly set, even when you query
+	* DNSSEC is never automatically set, even when you query
 	  for DNSKEY/RRSIG or DS.
 	* Implement a crude RTT check, it now distinguishes between
 	  reachable and unreachable.
@@ -1017,7 +1017,7 @@
 	* char *_when was removed from the ldns_pkt structure
 
 18 Oct 2005: 1.0.0: ldns-team
-	* Commited a patch from Håkan Olsson
+	* Committed a patch from Håkan Olsson
 	* Added UPDATE support (Jakob Schlyter and Håkan Olsson)
 	* License change: ldns is now BSD licensed
 	* ldns now depends on SSL
@@ -1059,7 +1059,7 @@
 
 23 May 2005: 0.60: ldns-team
 	* Removed config.h from the header installed files
-	  (you're not supposed to include that in a libary)
+	  (you're not supposed to include that in a library)
 	* Further tweaking
 	  - DNSSEC signing/verification works
 	  - Assorted bug fixes and tweaks (memory management)

--- a/contrib/ldnsx/ldnsx.py
+++ b/contrib/ldnsx/ldnsx.py
@@ -384,7 +384,7 @@ class resolver:
 			>>>       tlds.append(rr.owner())
 
 		"""
-		#Dname seems to be unecessary on some computers, but it is on others. Avoid bugs.
+		#Dname seems to be unnecessary on some computers, but it is on others. Avoid bugs.
 		if self._ldns_resolver.axfr_start(ldns.ldns_dname(name), ldns.LDNS_RR_CLASS_IN) != ldns.LDNS_STATUS_OK:
 			raise Exception("Starting AXFR failed. Error: %s" % ldns.ldns_get_errorstr_by_id(status))
 		pres = self._ldns_resolver.axfr_next()

--- a/contrib/python/docs/source/install.rst
+++ b/contrib/python/docs/source/install.rst
@@ -14,7 +14,7 @@ is required.
 
 **Download**
 
-The lates source codes can be downloaded from `here`_.
+The latest source codes can be downloaded from `here`_.
 
 .. _here: http://nlnetlabs.nl/projects/ldns/
 

--- a/contrib/python/examples/test_dname.py
+++ b/contrib/python/examples/test_dname.py
@@ -44,7 +44,7 @@ if True:
     except:
         set_error()
     #
-    # Error when printing a dname wich was created from an empty string.
+    # Error when printing a dname which was created from an empty string.
     # Must find out why.
     #
     try:

--- a/contrib/python/ldns_resolver.i
+++ b/contrib/python/ldns_resolver.i
@@ -350,7 +350,7 @@ record."
                Creates a resolver object from given file name
                
                :param filename: Name of file which contains resolver
-                   informations (usually /etc/resolv.conf).
+                   information (usually /etc/resolv.conf).
                :type filename: str
                :param raiseException: If True, an exception occurs in case a
                    resolver object can't be created.

--- a/contrib/python/ldns_zone.i
+++ b/contrib/python/ldns_zone.i
@@ -216,7 +216,7 @@ The ``zone.txt`` file contains the following records::
                
                :param rr:
                    the rr to add
-               :returns: (bool) a true on succes otherwise falsed
+               :returns: (bool) a true on success otherwise falsed
             """
             return _ldns.ldns_zone_push_rr(self,rr)
             #parameters: ldns_zone *,ldns_rr *,
@@ -229,7 +229,7 @@ The ``zone.txt`` file contains the following records::
                
                :param list:
                    the list to add
-               :returns: (bool) a true on succes otherwise falsed
+               :returns: (bool) a true on success otherwise falsed
             """
             return _ldns.ldns_zone_push_rr_list(self,list)
             #parameters: ldns_zone *,ldns_rr_list *,

--- a/dname.c
+++ b/dname.c
@@ -3,7 +3,7 @@
  *
  * dname specific rdata implementations
  * A dname is a rdf structure with type LDNS_RDF_TYPE_DNAME
- * It is not a /real/ type! All function must therefor check
+ * It is not a /real/ type! All function must therefore check
  * for LDNS_RDF_TYPE_DNAME.
  *
  * a Net::DNS like library for C

--- a/dnssec_zone.c
+++ b/dnssec_zone.c
@@ -631,7 +631,7 @@ ldns_dnssec_zone_new_frm_fp_l(ldns_dnssec_zone** z, FILE* fp, const ldns_rdf* or
 	   nsec3_ents (where ent is e.n.t.; i.e. empty non terminal) will
 	   hold the NSEC3s that still didn't have a matching name in the
 	   zone tree, even after all names were read.  They can only match
-	   after the zone is equiped with all the empty non terminals. */
+	   after the zone is equipped with all the empty non terminals. */
 	ldns_rbtree_t todo_nsec3_ents;
 	ldns_rbnode_t *new_node;
 	ldns_rr_list* todo_nsec3_rrsigs = ldns_rr_list_new();
@@ -705,7 +705,7 @@ ldns_dnssec_zone_new_frm_fp_l(ldns_dnssec_zone** z, FILE* fp, const ldns_rdf* or
 					my_ttl = ldns_rr_ttl(cur_rr);
 				}
 			/* When ttl is implicit, try to adhere to the rules as
-			 * much as posssible. (also for compatibility with bind)
+			 * much as possible. (also for compatibility with bind)
 			 * This was changed when fixing an issue with ZONEMD
 			 * which hashes the TTL too.
 			 */

--- a/doc/API-header.xml
+++ b/doc/API-header.xml
@@ -97,7 +97,7 @@ Further more it is to be expected that lDNS will depend on OpenSSL for
 its cryptography.
 </t>
 <t>
-As said, lDNS is modelled after Net::DNS, therefor its application API
+As said, lDNS is modelled after Net::DNS, therefore its application API
 looks very much like the one used for Net::DNS. Some modification are made
 of course, because not all functionality of Perl can be caught in C.
 </t>

--- a/doc/API.xml
+++ b/doc/API.xml
@@ -97,7 +97,7 @@ Further more it is to be expected that lDNS will depend on OpenSSL for
 its cryptography.
 </t>
 <t>
-As said, lDNS is modelled after Net::DNS, therefor its application API
+As said, lDNS is modelled after Net::DNS, therefore its application API
 looks very much like the one used for Net::DNS. Some modification are made
 of course, because not all functionality of Perl can be caught in C.
 </t>

--- a/doc/CodingStyle
+++ b/doc/CodingStyle
@@ -60,5 +60,5 @@ The libdns coding style guide
     arcount     = additional section count
 
 ldns-<tools>
-* use exit(EXIT_FAILURE)/ exit(SUCCES)
+* use exit(EXIT_FAILURE)/ exit(EXIT_SUCCESS)
 * 

--- a/examples/ldns-testns.1
+++ b/examples/ldns-testns.1
@@ -1,7 +1,7 @@
 .TH ldns-testns 1 "14 Dec 2006"
 .SH NAME
 ldns-testns \- simple fake nameserver tool
-.SH SYNOPSYS
+.SH SYNOPSIS
 .B ldns-testns
 [
 .IR OPTION
@@ -11,7 +11,7 @@ ldns-testns \- simple fake nameserver tool
 .SH DESCRIPTION
 \fBldns-testns\fR can be used to provide answers to DNS queries for
 testing.  The answers are premade, and can be tailored to testing
-needs. The answers can be wildly invalid or unparseable.
+needs. The answers can be wildly invalid or unparsable.
 
 This program is a debugging aid. It is not efficient, especially
 with a long config file, but it can give any reply to any query.

--- a/examples/nsd-test/nsd-ldnsd.c
+++ b/examples/nsd-test/nsd-ldnsd.c
@@ -83,7 +83,7 @@ main(int argc, char **argv)
 				usage(stdout);
 				exit(EXIT_FAILURE);
 			} else {
-				fprintf(stderr, "quiting after %d qs\n", (int)maxcount);
+				fprintf(stderr, "quitting after %d qs\n", (int)maxcount);
 			}
 		} else {
 			fprintf(stderr, "Use -Number for max count\n");

--- a/ldns/dane.h
+++ b/ldns/dane.h
@@ -43,7 +43,7 @@ enum ldns_enum_tlsa_certificate_usage
 	/** CA constraint */
 	LDNS_TLSA_USAGE_PKIX_TA				=   0,
 	LDNS_TLSA_USAGE_CA_CONSTRAINT			=   0,
-	/** Sevice certificate constraint */
+	/** Service certificate constraint */
 	LDNS_TLSA_USAGE_PKIX_EE				=   1,
 	LDNS_TLSA_USAGE_SERVICE_CERTIFICATE_CONSTRAINT	=   1,
 	/** Trust anchor assertion */

--- a/ldns/dnssec.h
+++ b/ldns/dnssec.h
@@ -355,7 +355,7 @@ uint8_t ldns_nsec3_salt_length(const ldns_rr *nsec3_rr);
 /**
  * Returns the salt bytes used in the given NSEC3 RR
  * \param[in] *nsec3_rr The RR to read from
- * \return The salt in bytes, this is alloced, so you need to free it
+ * \return The salt in bytes, this is alloc'ed, so you need to free it
  */
 uint8_t *ldns_nsec3_salt_data(const ldns_rr *nsec3_rr);
 

--- a/ldns/dnssec_sign.h
+++ b/ldns/dnssec_sign.h
@@ -113,7 +113,7 @@ ldns_dnssec_zone_mark_and_get_glue(
  * be taken into account separately.
  *
  * \param[in] zone the zone in which to mark the names
- * \return LDNS_STATUS_OK on succesful completion, an error code otherwise
+ * \return LDNS_STATUS_OK on successful completion, an error code otherwise
  */
 ldns_status
 ldns_dnssec_zone_mark_glue(ldns_dnssec_zone *zone);

--- a/ldns/dnssec_zone.h
+++ b/ldns/dnssec_zone.h
@@ -53,7 +53,7 @@ struct ldns_struct_dnssec_name
 	 * Usually, the name is a pointer to the owner name of the first rr for
 	 * this name, but sometimes there is no actual data to point to, 
 	 * for instance in
-	 * names representing empty nonterminals. If so, set alloced to true to
+	 * names representing empty nonterminals. If so, set name_alloced to true to
 	 * indicate that this data must also be freed when the name is freed
 	 */
 	bool name_alloced;

--- a/ldns/parse.h
+++ b/ldns/parse.h
@@ -112,9 +112,9 @@ ssize_t ldns_bget_token(ldns_buffer *b, char *token, const char *delim, size_t l
  * after the keyword + k_del until we hit d_del
  * \param[in] f file pointer to read from
  * \param[in] keyword keyword to look for
- * \param[in] k_del keyword delimeter 
+ * \param[in] k_del keyword delimiter 
  * \param[out] data the data found 
- * \param[in] d_del the data delimeter
+ * \param[in] d_del the data delimiter
  * \param[in] data_limit maximum size the the data buffer
  * \return the number of character read
  */
@@ -125,9 +125,9 @@ ssize_t ldns_fget_keyword_data(FILE *f, const char *keyword, const char *k_del, 
  * after the keyword + k_del until we hit d_del
  * \param[in] f file pointer to read from
  * \param[in] keyword keyword to look for
- * \param[in] k_del keyword delimeter 
+ * \param[in] k_del keyword delimiter 
  * \param[out] data the data found 
- * \param[in] d_del the data delimeter
+ * \param[in] d_del the data delimiter
  * \param[in] data_limit maximum size the the data buffer
  * \param[in] line_nr pointer to an integer containing the current line number (for
 debugging purposes)
@@ -140,9 +140,9 @@ ssize_t ldns_fget_keyword_data_l(FILE *f, const char *keyword, const char *k_del
  * after the keyword + k_del until we hit d_del
  * \param[in] b buffer pointer to read from
  * \param[in] keyword keyword to look for
- * \param[in] k_del keyword delimeter 
+ * \param[in] k_del keyword delimiter 
  * \param[out] data the data found 
- * \param[in] d_del the data delimeter
+ * \param[in] d_del the data delimiter
  * \param[in] data_limit maximum size the the data buffer
  * \return the number of character read
  */

--- a/ldns/zone.h
+++ b/ldns/zone.h
@@ -97,7 +97,7 @@ void ldns_zone_set_rrs(ldns_zone *z, ldns_rr_list *rrlist);
  * copying, so the rr_list structure inside z is modified!
  * \param[in] z the zone to add to
  * \param[in] list the list to add
- * \return a true on succes otherwise falsed
+ * \return a true on success otherwise false
  */
 bool ldns_zone_push_rr_list(ldns_zone *z, const ldns_rr_list *list);
 
@@ -106,7 +106,7 @@ bool ldns_zone_push_rr_list(ldns_zone *z, const ldns_rr_list *list);
  * copying, so the rr_list structure inside z is modified!
  * \param[in] z the zone to add to
  * \param[in] rr the rr to add
- * \return a true on succes otherwise falsed
+ * \return a true on success otherwise false
  */
 bool ldns_zone_push_rr(ldns_zone *z, ldns_rr *rr);
 

--- a/packaging/fedora/ldns.spec
+++ b/packaging/fedora/ldns.spec
@@ -23,7 +23,7 @@ BuildRequires:  python-devel, swig
 %endif
 
 %description
-ldns is a library with the aim to simplify DNS programing in C. All
+ldns is a library with the aim to simplify DNS programming in C. All
 lowlevel DNS/DNSSEC operations are supported. We also define a higher
 level API which allows a programmer to (for instance) create or sign
 packets.

--- a/pcat/pcat-diff.c
+++ b/pcat/pcat-diff.c
@@ -174,25 +174,25 @@ void
 print_known_differences(FILE *output)
 {
 	size_t i;
-	size_t differents = 0;
+	size_t difference_count = 0;
 	size_t total;
 	double percentage;
 	
 	qsort(known_differences, known_differences_size, sizeof(known_differences_count),
 	      compare_known_differences);
 	for (i = 0; i < known_differences_size; i++) {
-		differents += known_differences[i].count;
+		difference_count += known_differences[i].count;
 	}
 
-	total = differents + sames;
+	total = difference_count + sames;
 
 	for (i = 0; i < known_differences_size; i++) {
-		percentage = (double) (((double) known_differences[i].count / (double)differents) * 100.0);
+		percentage = (double) (((double) known_differences[i].count / (double)difference_count) * 100.0);
 		fprintf(output, "%-48s", known_differences[i].descr);
 		fprintf(output, "%8u\t(%02.2f%%)\n", (unsigned int) known_differences[i].count, percentage);
 	}
 
-	fprintf(output, "Total number of differences: %u (100%%)\n", (unsigned int) differents);
+	fprintf(output, "Total number of differences: %u (100%%)\n", (unsigned int) difference_count);
 	fprintf(output, "Number of packets the same after normalization: %u\n", (unsigned int) sames);
 	fprintf(output, "Number of packets exactly the same on the wire: %u\n", (unsigned int) bytesames);
 	fprintf(output, "Total number of packets inspected: %u\n", (unsigned int) total);

--- a/pcat/pcat-diff.c
+++ b/pcat/pcat-diff.c
@@ -498,7 +498,7 @@ compare_to_file(ldns_pkt *qp, ldns_pkt *pkt1, ldns_pkt *pkt2)
 
 		/* first, try query match */
 		
-		/* special case for unparseable queries */
+		/* special case for unparsable queries */
 		if (!qp) {
 			if (strncmp(query_match, "BADPACKET\n", 11) == 0 ||
 			    strncmp(query_match, "*\n", 3) == 0
@@ -664,7 +664,7 @@ compare_to_file(ldns_pkt *qp, ldns_pkt *pkt1, ldns_pkt *pkt2)
 		/* ok the query matches, now look at both answers */
 
 		/* special case if one packet is null (ie. one server
-		   answers and one doesnt) */
+		   answers and one doesn't) */
 		if (same && (!pkt1 || !pkt2)) {
 			if (strncmp(answer_match, "NOANSWER\n", 10) == 0 || 
 			    strncmp(answer_match, "*\n", 3) == 0

--- a/rdata.c
+++ b/rdata.c
@@ -624,7 +624,7 @@ ldns_octet(char *word, size_t *length)
                         return LDNS_STATUS_DDD_OVERFLOW;
                     }
                 } else {
-                    /* an espaced character, like \<space> ? 
+                    /* an escaped character, like \<space> ? 
                     * remove the '\' keep the rest */
                     *p = *++s;
                     (*length)++;

--- a/rr.c
+++ b/rr.c
@@ -1323,7 +1323,7 @@ ldns_rr_set_push_rr(ldns_rr_list *rr_list, ldns_rr *rr)
 			return false;
 		}
 		/* ok, still alive - check if the rr already
-		 * exists - if so, dont' add it */
+		 * exists - if so, don't add it */
 		for(i = 0; i < rr_count; i++) {
 			if(ldns_rr_compare(
 					ldns_rr_list_rr(rr_list, i), rr) == 0) {

--- a/rr_functions.c
+++ b/rr_functions.c
@@ -24,7 +24,7 @@
  * return a specific rdf
  * \param[in] type type of RR
  * \param[in] rr   the rr itself
- * \param[in] pos  at which postion to get it
+ * \param[in] pos  at which position to get it
  * \return the rdf sought
  */
 static ldns_rdf *
@@ -41,7 +41,7 @@ ldns_rr_function(ldns_rr_type type, const ldns_rr *rr, size_t pos)
  * \param[in] type type of RR
  * \param[in] rr   the rr itself
  * \param[in] rdf  the rdf to set
- * \param[in] pos  at which postion to set it
+ * \param[in] pos  at which position to set it
  * \return true or false
  */
 static bool

--- a/zone.c
+++ b/zone.c
@@ -253,7 +253,7 @@ ldns_zone_new_frm_fp_l(ldns_zone **z, FILE *fp, const ldns_rdf *origin,
 					my_ttl = ldns_rr_ttl(rr);
 				}
 			/* When ttl is implicit, try to adhere to the rules as
-			 * much as posssible. (also for compatibility with bind)
+			 * much as possible. (also for compatibility with bind)
 			 * This was changed when fixing an issue with ZONEMD
 			 * which hashes the TTL too.
 			 */


### PR DESCRIPTION
In #171 i think some attempts at spelling cleanup caused problems.  This series applies more spelling cleanup, and i think it should not cause any problems, but please do review it first :)

If we can get the codebase to a state that a standard spellchecker like "codespell" can run over it with no complaints, then you can build a codespell run into your static analysis to avoid introducing any misspellings.

This series doesn't get it to be fully-clean with codespell 2.1.0-1, but it's much closer.