### PR TITLE
Free line memory even if zone file parsing fails

### DIFF
--- a/rr.c
+++ b/rr.c
@@ -741,9 +741,10 @@ _ldns_rr_new_frm_fp_l_internal(ldns_rr **newrr, FILE *fp,
 	}
 	/* read an entire line in from the file */
 	if ((s = ldns_fget_token_l_st( fp, &line, &limit, false
-	                             , LDNS_PARSE_SKIP_SPACE, line_nr)))
+	                             , LDNS_PARSE_SKIP_SPACE, line_nr))) {
 		LDNS_FREE(line);
 		return s;
+	}
 
 	if (strncmp(line, "$ORIGIN", 7) == 0 && isspace((unsigned char)line[7])) {
 		if (*origin) {

--- a/rr.c
+++ b/rr.c
@@ -742,6 +742,7 @@ _ldns_rr_new_frm_fp_l_internal(ldns_rr **newrr, FILE *fp,
 	/* read an entire line in from the file */
 	if ((s = ldns_fget_token_l_st( fp, &line, &limit, false
 	                             , LDNS_PARSE_SKIP_SPACE, line_nr)))
+		LDNS_FREE(line);
 		return s;
 
 	if (strncmp(line, "$ORIGIN", 7) == 0 && isspace((unsigned char)line[7])) {


### PR DESCRIPTION
Fixes #178. Frees line buffer if return code is nonzero.

Question: Fix here or fix in `ldns_fget_token_l_st` to not leave allocated mem if returning nonzero?