### PR TITLE
Homogenize paths for source files during compilation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -137,7 +137,7 @@ all:	setup-builddir lib linktest manpages @P5_DNS_LDNS@ @PYLDNS@ @DRILL@ @EXAMPL
 	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $< -o $@
 
 $(LDNS_LOBJS) $(LIBLOBJS) $(DRILL_LOBJS) $(EXAMPLE_LOBJS):
-	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $(srcdir)/$(@:.lo=.c) -o $@
+	$(COMP_LIB) $(LIBSSL_CPPFLAGS) -c $(@:.lo=.c) -o $@
 
 setup-builddir:
 	@if test ! -d compat ; then mkdir compat ; fi


### PR DESCRIPTION
Why:

* Compiling a `.o` file alone will compile with `-c file.c`
* Compiling a `.lo` file alone will create the corresponding .o files with `-c ./file.c`
* Building with `make -j1` will only execute the `.lo` rules; the `.o` rules will be skipped since the `.o` files are already created from the `.lo` rules with option `-c ./file.c`
* Building with `make -j2` will execute the `.lo` rules and the `.o` rules in parallel, creating the `.o` file with option `-c file.c`
* `assert()` captures the path of the source file (taken from the `-c` option) in the compiled binary in order to display the source of the assertion error
* Hence the compiled binaries are not reproducible depending on the number of make parallel jobs

Example:

* when compiling `examples/ldns-dane` with `make -j1`, the binary contains the string `./examples/ldns-dane.c`
* when compiling `examples/ldns-dane` with `make -j2`, the binary contains the string `examples/ldns-dane.c`