### PR TITLE
acx_nlnetlabs.m4: fix -Wstrict-prototypes

### DIFF
--- a/acx_nlnetlabs.m4
+++ b/acx_nlnetlabs.m4
@@ -183,7 +183,7 @@ dnl cache=`echo $1 | sed 'y%.=/+- %___p__%'`
 AC_CACHE_VAL(cv_prog_cc_flag_needed_$cache,
 [
 echo '$2' > conftest.c
-echo 'void f(){}' >>conftest.c
+echo 'void f(void){}' >>conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS $ERRFLAG -c conftest.c 2>&1`"; then
 eval "cv_prog_cc_flag_needed_$cache=no"
 else
@@ -229,7 +229,7 @@ dnl DEPFLAG: set to flag that generates dependencies.
 AC_DEFUN([ACX_DEPFLAG],
 [
 AC_MSG_CHECKING([$CC dependency flag])
-echo 'void f(){}' >conftest.c
+echo 'void f(void){}' >conftest.c
 if test "`$CC -MM conftest.c 2>&1`" = "conftest.o: conftest.c"; then
 	DEPFLAG="-MM"
 else 
@@ -268,7 +268,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED($C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAUL
 #include <getopt.h>
 #endif
 
-int test() {
+int test(void) {
 	int a;
 	char **opts = NULL;
 	struct timeval tv;
@@ -305,7 +305,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED($C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAUL
 #include <getopt.h>
 #endif
 
-int test() {
+int test(void) {
 	int a;
 	char **opts = NULL;
 	struct timeval tv;
@@ -331,7 +331,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED($C99FLAG,
 [
 #include <stdbool.h>
 #include <ctype.h>
-int test() {
+int test(void) {
         int a = 0;
         return a;
 }
@@ -341,7 +341,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED(-D_BSD_SOURCE -D_DEFAULT_SOURCE,
 [
 #include <ctype.h>
 
-int test() {
+int test(void) {
         int a;
         a = isascii(32);
         return a;
@@ -352,7 +352,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED(-D_GNU_SOURCE,
 [
 #include <netinet/in.h>
 
-int test() {
+int test(void) {
         struct in6_pktinfo inf;
 	int a = (int)sizeof(inf);
         return a;
@@ -366,7 +366,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED(-D_GNU_SOURCE -D_FRSRESGID,
 [
 #include <unistd.h>
 
-int test() {
+int test(void) {
 	int a = setresgid(0,0,0);
 	a = setresuid(0,0,0);
         return a;
@@ -381,7 +381,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED(-D_POSIX_C_SOURCE=200112,
 #endif
 #include <netdb.h>
 
-int test() {
+int test(void) {
         int a = 0;
         char *t;
         time_t time = 0;
@@ -409,7 +409,7 @@ ACX_CHECK_COMPILER_FLAG_NEEDED(-D__EXTENSIONS__,
 #include <getopt.h>
 #endif
 
-int test() {
+int test(void) {
         int a;
         char **opts = NULL;
         struct timeval tv;
@@ -809,7 +809,7 @@ dnl try to see if an additional _LARGEFILE_SOURCE 1 is needed to get fseeko
 ACX_CHECK_COMPILER_FLAG_NEEDED(-D_LARGEFILE_SOURCE=1,
 [
 #include <stdio.h>
-int test() {
+int test(void) {
         int a = fseeko(stdin, 0, 0);
         return a;
 }
@@ -834,7 +834,7 @@ char* (*f) () = getaddrinfo;
 #ifdef __cplusplus
 }
 #endif
-int main() {
+int main(void) {
         ;
         return 0;
 }
@@ -898,7 +898,7 @@ cache=`echo $1 | sed 'y%.=/+-%___p_%'`
 AC_CACHE_VAL(cv_cc_deprecated_$cache,
 [
 echo '$3' >conftest.c
-echo 'void f(){ $2 }' >>conftest.c
+echo 'void f(void){ $2 }' >>conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -c conftest.c 2>&1 | grep -e deprecated -e unavailable`"; then
 eval "cv_cc_deprecated_$cache=no"
 else


### PR DESCRIPTION
Fix -Wstrict-prototypes as it's easy to do and avoids future warnings. Noticed when doing Clang 16 / GCC 14 / C23 work.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2], or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213 [2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Signed-off-by: Sam James <sam@gentoo.org>