### PR TITLE
Make test suite link to static LDNS rather than dynamic.

### DIFF
--- a/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.Makefile.in
+++ b/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.Makefile.in
@@ -13,8 +13,8 @@ datarootdir = @datarootdir@
 CC = @CC@
 CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@ @LIBSSL_CPPFLAGS@ -I../..
-LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@ -L../../.libs
-LIBS = @LIBS@ @LIBSSL_SSL_LIBS@ -lldns
+LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@
+LIBS = @LIBS@ @LIBSSL_SSL_LIBS@
 
 # Hmmm gcc 4.6.1 expects $(LIBS) as the last argument
 
@@ -31,7 +31,7 @@ TESTS		= 12-unit-tests-dnssec
 all:	$(TESTS)
 
 12-unit-tests-dnssec:	12-unit-tests-dnssec.o
-		$(LINK) -o $@ $+ $(LIBS)
+		$(LINK) -o $@ $+ ../../.libs/libldns.a $(LIBS)
 
 clean:
 	rm -f *.o

--- a/test/13-unit-tests-base.tpkg/13-unit-tests-base.Makefile.in
+++ b/test/13-unit-tests-base.tpkg/13-unit-tests-base.Makefile.in
@@ -13,8 +13,8 @@ datarootdir = @datarootdir@
 CC = @CC@
 CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@ @LIBSSL_CPPFLAGS@ -I../..
-LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@ -L../../.libs
-LIBS = @LIBS@ @LIBSSL_SSL_LIBS@ -lldns
+LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@
+LIBS = @LIBS@ @LIBSSL_SSL_LIBS@
 
 COMPILE         = $(CC) $(CPPFLAGS) $(CFLAGS)
 LINK            = $(CC) $(CFLAGS) $(LDFLAGS)
@@ -29,7 +29,7 @@ TESTS		= 13-unit-tests-base
 all:	$(TESTS)
 
 13-unit-tests-base:	13-unit-tests-base.o
-		$(LINK) -o $@ $+ $(LIBS)
+		$(LINK) -o $@ $+ ../../.libs/libldns.a $(LIBS)
 
 clean:
 	rm -f *.o

--- a/test/15-unit-tests-rrtypes.tpkg/15-unit-tests-rrtypes.Makefile.in
+++ b/test/15-unit-tests-rrtypes.tpkg/15-unit-tests-rrtypes.Makefile.in
@@ -13,8 +13,8 @@ datarootdir = @datarootdir@
 CC = @CC@
 CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@ @LIBSSL_CPPFLAGS@ -I../..
-LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@ -L../../.libs
-LIBS = @LIBS@ @LIBSSL_SSL_LIBS@ -lldns
+LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@
+LIBS = @LIBS@ @LIBSSL_SSL_LIBS@
 
 COMPILE         = $(CC) $(CPPFLAGS) $(CFLAGS)
 LINK            = $(CC) $(CFLAGS) $(LDFLAGS)
@@ -29,7 +29,7 @@ TESTS		= 15-unit-tests-rrtypes
 all:	$(TESTS)
 
 15-unit-tests-rrtypes:	15-unit-tests-rrtypes.o
-		$(LINK) -o $@ $+ $(LIBS)
+		$(LINK) -o $@ $+ ../../.libs/libldns.a $(LIBS)
 
 clean:
 	rm -f *.o

--- a/test/16-unit-tests-edns.tpkg/16-unit-tests-edns.Makefile.in
+++ b/test/16-unit-tests-edns.tpkg/16-unit-tests-edns.Makefile.in
@@ -13,8 +13,8 @@ datarootdir = @datarootdir@
 CC = @CC@
 CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@ @LIBSSL_CPPFLAGS@ -I../..
-LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@ -L../../.libs
-LIBS = @LIBS@ @LIBSSL_SSL_LIBS@ -lldns
+LDFLAGS = @LDFLAGS@ @LIBSSL_LDFLAGS@
+LIBS = @LIBS@ @LIBSSL_SSL_LIBS@
 
 COMPILE         = $(CC) $(CPPFLAGS) $(CFLAGS)
 LINK            = $(CC) $(CFLAGS) $(LDFLAGS)
@@ -29,7 +29,7 @@ TESTS		= 16-unit-tests-edns
 all:	$(TESTS)
 
 16-unit-tests-edns:	16-unit-tests-edns.o
-		$(LINK) -o $@ $+ $(LIBS)
+		$(LINK) -o $@ $+ ../../.libs/libldns.a $(LIBS)
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
Issue #197: Cygwin fails these tests because it’s dicey to link dynamically to a library version that isn’t installed in the $PATH. Rather than adding platform-specific logic, this changeset alters the test suite to link statically rather than dynamically, which alleviates the problem.

Notably, this doesn’t resolve all problems with Cygwin in the test suite; other tests fail for other reasons. (See the GitHub issue for details.)