### PR TITLE
Run autoupdate on configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-AC_PREREQ(2.56)
+AC_PREREQ([2.71])
 sinclude(acx_nlnetlabs.m4)
 
 # must be numbers. ac_defun because of later processing.
 m4_define([VERSION_MAJOR],[1])
 m4_define([VERSION_MINOR],[8])
 m4_define([VERSION_MICRO],[3])
-AC_INIT(ldns, m4_defn([VERSION_MAJOR]).m4_defn([VERSION_MINOR]).m4_defn([VERSION_MICRO]), libdns@nlnetlabs.nl, libdns)
+AC_INIT([ldns],[m4_defn(VERSION_MAJOR).m4_defn(VERSION_MINOR).m4_defn(VERSION_MICRO)],[libdns@nlnetlabs.nl],[libdns])
 AC_CONFIG_SRCDIR([packet.c])
 # needed to build correct soname
 AC_SUBST(LDNS_VERSION_MAJOR, [VERSION_MAJOR])
@@ -36,7 +36,7 @@ AC_SUBST(LDNS_VERSION_MICRO, [VERSION_MICRO])
 #
 AC_SUBST(VERSION_INFO, [8:0:5])
 
-AC_AIX
+AC_USE_SYSTEM_EXTENSIONS
 if test "$ac_cv_header_minix_config_h" = "yes"; then
 	AC_DEFINE(_NETBSD_SOURCE,1, [Enable for compile on Minix])
 fi
@@ -89,7 +89,7 @@ COPY_FILES($srcdir/$1/*.h, $2)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
-AC_LANG_C
+AC_LANG([C])
 if test "x$CFLAGS" = "x" ; then
 ACX_CHECK_COMPILER_FLAG(g, [CFLAGS="-g"])
 ACX_CHECK_COMPILER_FLAG(O2, [CFLAGS="-O2 $CFLAGS"])
@@ -152,8 +152,7 @@ AC_CHECK_FUNC([inet_pton],
 ])
 
 
-AC_ARG_WITH(drill, AC_HELP_STRING([--with-drill],
- [Also build drill.]),
+AC_ARG_WITH(drill, AS_HELP_STRING([--with-drill],[Also build drill.]),
  [],[with_drill="no"])
 if test x_$with_drill != x_no ; then
 	AC_SUBST(DRILL,[drill])
@@ -177,8 +176,7 @@ else
 fi
 
 
-AC_ARG_WITH(examples, AC_HELP_STRING([--with-examples],
- [Also build examples.]),
+AC_ARG_WITH(examples, AS_HELP_STRING([--with-examples],[Also build examples.]),
  [],[with_examples="no"])
 if test x_$with_examples != x_no ; then
 	AC_SUBST(EXAMPLES,[examples])
@@ -202,7 +200,7 @@ else
 fi
 
 # add option to disable installation of ldns-config script
-AC_ARG_ENABLE(ldns-config, AC_HELP_STRING([--disable-ldns-config], [disable installation of ldns-config (default=enabled)]),
+AC_ARG_ENABLE(ldns-config, AS_HELP_STRING([--disable-ldns-config],[disable installation of ldns-config (default=enabled)]),
 	enable_ldns_config=$enableval, enable_ldns_config=yes)
 if test "x$enable_ldns_config" = xyes; then
 	AC_SUBST(INSTALL_CONFIG, [install-config])
@@ -217,7 +215,7 @@ else
 fi
 
 # add option to disable library printing to stderr
-AC_ARG_ENABLE(stderr-msgs, AC_HELP_STRING([--enable-stderr-msgs], [Enable printing to stderr (default=disabled)]), enable_stderr_msgs=$enableval, enable_stderr_msgs=no)
+AC_ARG_ENABLE(stderr-msgs, AS_HELP_STRING([--enable-stderr-msgs],[Enable printing to stderr (default=disabled)]), enable_stderr_msgs=$enableval, enable_stderr_msgs=no)
 case "$enable_stderr_msgs" in
     no) dnl default
         ;;
@@ -237,8 +235,7 @@ AX_CONFIG_FEATURE(
 PYTHON_X_CFLAGS=""
 ldns_with_pyldns=no
 ldns_with_pyldnsx=no
-AC_ARG_WITH(pyldns, AC_HELP_STRING([--with-pyldns],
- [generate python library, or --without-pyldns to disable Python support.]),
+AC_ARG_WITH(pyldns, AS_HELP_STRING([--with-pyldns],[generate python library, or --without-pyldns to disable Python support.]),
  [],[ withval="no" ])
 ldns_have_python=no
 if test x_$withval != x_no; then
@@ -293,8 +290,7 @@ fi
 AC_SUBST(PYTHON_X_CFLAGS)
 
 # Check for pyldnsx
-AC_ARG_WITH(pyldnsx, AC_HELP_STRING([--without-pyldnsx],
-  [Do not install the ldnsx python module, or --with-pyldnsx to install it.]),
+AC_ARG_WITH(pyldnsx, AS_HELP_STRING([--without-pyldnsx],[Do not install the ldnsx python module, or --with-pyldnsx to install it.]),
   [],[ withval="with_pyldns" ])
 if test x_$withval != x_no; then
   if test x_$ldns_with_pyldns != x_no; then
@@ -324,8 +320,7 @@ fi
 
 # check for perl
 ldns_with_p5_dns_ldns=no
-AC_ARG_WITH(p5-dns-ldns, AC_HELP_STRING([--with-p5-dns-ldns],
- [generate DNS::LDNS perl bindings]),
+AC_ARG_WITH(p5-dns-ldns, AS_HELP_STRING([--with-p5-dns-ldns],[generate DNS::LDNS perl bindings]),
  [],[ withval="no" ])
 ldns_have_perl=no
 if test x_$withval != x_no; then
@@ -390,7 +385,7 @@ So either no OpenSSL at all (the include already failed), or the version < 3.0.0
 #AC_CHECK_PROG(glibtool, glibtool, [glibtool], )
 #AC_CHECK_PROGS(libtool, [libtool15 libtool], [./libtool])
 
-AC_ARG_ENABLE(sha2, AC_HELP_STRING([--disable-sha2], [Disable SHA256 and SHA512 RRSIG support]))
+AC_ARG_ENABLE(sha2, AS_HELP_STRING([--disable-sha2],[Disable SHA256 and SHA512 RRSIG support]))
 case "$enable_sha2" in
     no)
         ;;
@@ -515,7 +510,7 @@ eval "ac_cv_c_gost_works=maybe"
 fi
 ])dnl
 
-AC_ARG_ENABLE(gost, AC_HELP_STRING([--disable-gost], [Disable GOST support]))
+AC_ARG_ENABLE(gost, AS_HELP_STRING([--disable-gost],[Disable GOST support]))
 case "$enable_gost" in
     no)
         ;;
@@ -527,7 +522,7 @@ case "$enable_gost" in
         AC_CHECK_FUNC(EVP_PKEY_set_type_str, [],[AC_MSG_ERROR([OpenSSL >= 1.0.0 is needed for GOST support or rerun with --disable-gost])])
         AC_CHECK_FUNC(EC_KEY_new, [], [AC_MSG_ERROR([No ECC functions found in OpenSSL: please upgrade OpenSSL or rerun with --disable-gost])])
 	AC_CHECK_GOST_WORKS
-	AC_ARG_ENABLE(gost-anyway, AC_HELP_STRING([--enable-gost-anyway], [Enable GOST even without a GOST engine installed]))
+	AC_ARG_ENABLE(gost-anyway, AS_HELP_STRING([--enable-gost-anyway],[Enable GOST even without a GOST engine installed]))
 	if test "$ac_cv_c_gost_works" != "no" -o "$enable_gost_anyway" = "yes"; then
 		if test "$ac_cv_c_gost_works" = "no"; then
 			AC_MSG_RESULT([no, but compiling with GOST support anyway])
@@ -545,7 +540,7 @@ case "$enable_gost" in
         ;;
 esac
 
-AC_ARG_ENABLE(ecdsa, AC_HELP_STRING([--disable-ecdsa], [Disable ECDSA support]))
+AC_ARG_ENABLE(ecdsa, AS_HELP_STRING([--disable-ecdsa],[Disable ECDSA support]))
 case "$enable_ecdsa" in
     no)
       ;;
@@ -563,7 +558,7 @@ case "$enable_ecdsa" in
       ;;
 esac
 
-AC_ARG_ENABLE(dsa, AC_HELP_STRING([--disable-dsa], [Disable DSA support]))
+AC_ARG_ENABLE(dsa, AS_HELP_STRING([--disable-dsa],[Disable DSA support]))
 case "$enable_dsa" in
     no)
       AC_SUBST(ldns_build_config_use_dsa, 0)
@@ -579,7 +574,7 @@ case "$enable_dsa" in
       ;;
 esac
 
-AC_ARG_ENABLE(ed25519, AC_HELP_STRING([--disable-ed25519], [Disable (experimental) ED25519 support. Default is detect]))
+AC_ARG_ENABLE(ed25519, AS_HELP_STRING([--disable-ed25519],[Disable (experimental) ED25519 support. Default is detect]))
 case "$enable_ed25519" in
     no)
       AC_SUBST(ldns_build_config_use_ed25519, 0)
@@ -596,7 +591,7 @@ case "$enable_ed25519" in
       ;;
 esac
 
-AC_ARG_ENABLE(ed448, AC_HELP_STRING([--disable-ed448], [Disable (experimental) ED448 support. Default is detect]))
+AC_ARG_ENABLE(ed448, AS_HELP_STRING([--disable-ed448],[Disable (experimental) ED448 support. Default is detect]))
 case "$enable_ed448" in
     no)
       AC_SUBST(ldns_build_config_use_ed448, 0)
@@ -613,9 +608,9 @@ case "$enable_ed448" in
       ;;
 esac
 
-AC_ARG_ENABLE(dane, AC_HELP_STRING([--disable-dane], [Disable DANE support]))
-AC_ARG_ENABLE(dane-verify, AC_HELP_STRING([--disable-dane-verify], [Disable DANE verify support]))
-AC_ARG_ENABLE(dane-ta-usage, AC_HELP_STRING([--disable-dane-ta-usage], [Disable DANE-TA usage type support]))
+AC_ARG_ENABLE(dane, AS_HELP_STRING([--disable-dane],[Disable DANE support]))
+AC_ARG_ENABLE(dane-verify, AS_HELP_STRING([--disable-dane-verify],[Disable DANE verify support]))
+AC_ARG_ENABLE(dane-ta-usage, AS_HELP_STRING([--disable-dane-ta-usage],[Disable DANE-TA usage type support]))
 
 AC_ARG_ENABLE(full-dane,, [
 	enable_dane_ta_usage=yes
@@ -671,7 +666,7 @@ case "$enable_dane" in
       ;;
 esac
 
-AC_ARG_ENABLE(rrtype-ninfo, AC_HELP_STRING([--enable-rrtype-ninfo], [Enable draft RR type ninfo.]))
+AC_ARG_ENABLE(rrtype-ninfo, AS_HELP_STRING([--enable-rrtype-ninfo],[Enable draft RR type ninfo.]))
 case "$enable_rrtype_ninfo" in
 	yes)
 		AC_DEFINE_UNQUOTED([RRTYPE_NINFO], [], [Define this to enable RR type NINFO.])
@@ -679,7 +674,7 @@ case "$enable_rrtype_ninfo" in
 	no|*)
 		;;
 esac
-AC_ARG_ENABLE(rrtype-rkey, AC_HELP_STRING([--enable-rrtype-rkey], [Enable draft RR type rkey.]))
+AC_ARG_ENABLE(rrtype-rkey, AS_HELP_STRING([--enable-rrtype-rkey],[Enable draft RR type rkey.]))
 case "$enable_rrtype_rkey" in
 	yes)
 		AC_DEFINE_UNQUOTED([RRTYPE_RKEY], [], [Define this to enable RR type RKEY.])
@@ -687,7 +682,7 @@ case "$enable_rrtype_rkey" in
 	no|*)
 		;;
 esac
-AC_ARG_ENABLE(rrtype-openpgpkey, AC_HELP_STRING([--disable-rrtype-openpgpkey], [Disable openpgpkey RR type.]))
+AC_ARG_ENABLE(rrtype-openpgpkey, AS_HELP_STRING([--disable-rrtype-openpgpkey],[Disable openpgpkey RR type.]))
 case "$enable_rrtype_openpgpkey" in
 	no)
 		;;
@@ -695,7 +690,7 @@ case "$enable_rrtype_openpgpkey" in
 		AC_DEFINE_UNQUOTED([RRTYPE_OPENPGPKEY], [], [Define this to enable RR type OPENPGPKEY.])
 		;;
 esac
-AC_ARG_ENABLE(rrtype-ta, AC_HELP_STRING([--enable-rrtype-ta], [Enable draft RR type ta.]))
+AC_ARG_ENABLE(rrtype-ta, AS_HELP_STRING([--enable-rrtype-ta],[Enable draft RR type ta.]))
 case "$enable_rrtype_ta" in
 	yes)
 		AC_DEFINE_UNQUOTED([RRTYPE_TA], [], [Define this to enable RR type TA.])
@@ -703,7 +698,7 @@ case "$enable_rrtype_ta" in
 	no|*)
 		;;
 esac
-AC_ARG_ENABLE(rrtype-avc, AC_HELP_STRING([--enable-rrtype-avc], [Enable draft RR type avc.]))
+AC_ARG_ENABLE(rrtype-avc, AS_HELP_STRING([--enable-rrtype-avc],[Enable draft RR type avc.]))
 case "$enable_rrtype_avc" in
 	yes)
 		AC_DEFINE_UNQUOTED([RRTYPE_AVC], [], [Define this to enable RR type AVC.])
@@ -711,7 +706,7 @@ case "$enable_rrtype_avc" in
 	no|*)
 		;;
 esac
-AC_ARG_ENABLE(rrtype-doa, AC_HELP_STRING([--enable-rrtype-doa], [Enable draft RR type DOA.]))
+AC_ARG_ENABLE(rrtype-doa, AS_HELP_STRING([--enable-rrtype-doa],[Enable draft RR type DOA.]))
 case "$enable_rrtype_doa" in
 	yes)
 		AC_DEFINE_UNQUOTED([RRTYPE_DOA], [], [Define this to enable RR type DOA.])
@@ -719,7 +714,7 @@ case "$enable_rrtype_doa" in
 	no|*)
 		;;
 esac
-AC_ARG_ENABLE(rrtype-amtrelay, AC_HELP_STRING([--enable-rrtype-amtrelay], [Enable draft RR type AMTRELAY.]))
+AC_ARG_ENABLE(rrtype-amtrelay, AS_HELP_STRING([--enable-rrtype-amtrelay],[Enable draft RR type AMTRELAY.]))
 case "$enable_rrtype_amtrelay" in
 	yes)
 		AC_DEFINE_UNQUOTED([RRTYPE_AMTRELAY], [], [Define this to enable RR type AMTRELAY.])
@@ -727,7 +722,7 @@ case "$enable_rrtype_amtrelay" in
 	no|*)
 		;;
 esac
-AC_ARG_ENABLE(rrtype-svcb-https, AC_HELP_STRING([--disable-rrtype-svcb-https], [Disable RR types SVCB and HTTPS.]))
+AC_ARG_ENABLE(rrtype-svcb-https, AS_HELP_STRING([--disable-rrtype-svcb-https],[Disable RR types SVCB and HTTPS.]))
 case "$enable_rrtype_svcb_https" in
 	no)
 		;;
@@ -777,6 +772,7 @@ AC_C_BIGENDIAN
 
 # Checks for header files.
 AC_HEADER_STDC
+
 AC_HEADER_STDBOOL
 #AC_HEADER_SYS_WAIT
 #AC_CHECK_HEADERS([getopt.h fcntl.h stdlib.h string.h strings.h unistd.h])
@@ -956,8 +952,7 @@ ACX_FUNC_IOCTLSOCKET
 ACX_CHECK_FORMAT_ATTRIBUTE
 ACX_CHECK_UNUSED_ATTRIBUTE
 
-AC_ARG_WITH(xcode-sdk, AC_HELP_STRING([--with-xcode-sdk],
- [Set xcode SDK version. Default is autodetect]),
+AC_ARG_WITH(xcode-sdk, AS_HELP_STRING([--with-xcode-sdk],[Set xcode SDK version. Default is autodetect]),
  [],[with_xcode_sdk="yes"])
 if test "x_$with_xcode_sdk" != "x_no" ; then
    # check OSX deployment target, if needed
@@ -985,14 +980,14 @@ fi
 
 AC_DEFINE([SYSCONFDIR], [sysconfdir], [System configuration dir])
 
-AC_ARG_WITH(trust-anchor, AC_HELP_STRING([--with-trust-anchor=KEYFILE], [Default location of the trust anchor file for drill and ldns-dane. [default=SYSCONFDIR/unbound/root.key]]), [
+AC_ARG_WITH(trust-anchor, AS_HELP_STRING([--with-trust-anchor=KEYFILE],[Default location of the trust anchor file for drill and ldns-dane. [default=SYSCONFDIR/unbound/root.key]]), [
  AC_SUBST([LDNS_TRUST_ANCHOR_FILE], ["$withval"])
  AC_MSG_NOTICE([Default trust anchor: $withval])
 ],[
  AC_SUBST([LDNS_TRUST_ANCHOR_FILE], ["\$(sysconfdir)/unbound/root.key"])
 ])
 
-AC_ARG_WITH(ca-file, AC_HELP_STRING([--with-ca-file=CAFILE], [File containing CA certificates for ldns-dane]), [
+AC_ARG_WITH(ca-file, AS_HELP_STRING([--with-ca-file=CAFILE],[File containing CA certificates for ldns-dane]), [
  AC_DEFINE([HAVE_DANE_CA_FILE], [1], [Is a CAFILE given at configure time])
  AC_DEFINE_UNQUOTED([LDNS_DANE_CA_FILE], ["$withval"], [Is a CAFILE given at configure time])
  AC_MSG_NOTICE([Using CAfile: $withval])
@@ -1002,7 +997,7 @@ AC_ARG_WITH(ca-file, AC_HELP_STRING([--with-ca-file=CAFILE], [File containing CA
  AC_SUBST(DEFAULT_CAFILE, [])
 ])
 
-AC_ARG_WITH(ca-path, AC_HELP_STRING([--with-ca-path=CAPATH], [Directory containing CA certificate files for ldns-dane]), [
+AC_ARG_WITH(ca-path, AS_HELP_STRING([--with-ca-path=CAPATH],[Directory containing CA certificate files for ldns-dane]), [
  AC_DEFINE([HAVE_DANE_CA_PATH], [1], [Is a CAPATH given at configure time])
  AC_DEFINE_UNQUOTED([LDNS_DANE_CA_PATH], ["$withval"], [Is a CAPATH given at configure time])
  AC_MSG_NOTICE([Using CApath: $withval])
@@ -1183,7 +1178,7 @@ CONFIG_FILES="Makefile libdns.doxygen ldns/common.h ldns/net.h ldns/util.h packa
 AC_SUBST(CONFIG_FILES)
 AC_CONFIG_FILES([$CONFIG_FILES])
 
-AC_CONFIG_HEADER([ldns/config.h])
+AC_CONFIG_HEADERS([ldns/config.h])
 AC_OUTPUT
 COPY_HEADER_FILES(ldns/, ldns/)
 


### PR DESCRIPTION
This cures all of the warnings, sans the `STDC_HEADERS` warning. I'm not terribly sure if taking it out would affect any platform supported by ldns, so I erred on the side of caution.

This change bumps the minimum required version of autoconf from 2.56 (released in 2003) to 2.71 (released in 2021).