### PR TITLE
ldns: fix the build in FreeBSD's base system

### DIFF
--- a/dnssec_zone.c
+++ b/dnssec_zone.c
@@ -605,10 +605,6 @@ ldns_todo_nsec3_ents_node_free(ldns_rbnode_t *node, void *arg) {
 	LDNS_FREE(node);
 }
 
-ldns_status _ldns_rr_new_frm_fp_l_internal(ldns_rr **newrr, FILE *fp,
-		uint32_t *default_ttl, ldns_rdf **origin, ldns_rdf **prev,
-		int *line_nr, bool *explicit_ttl);
-
 ldns_status
 ldns_dnssec_zone_new_frm_fp_l(ldns_dnssec_zone** z, FILE* fp, const ldns_rdf* origin,
 		uint32_t default_ttl, ldns_rr_class ATTR_UNUSED(c), int* line_nr)
@@ -1914,6 +1910,9 @@ rr_list2dnssec_rrs(ldns_rr_list *rr_list, ldns_dnssec_rrs **rrs,
 }
 
 
+ldns_status
+dnssec_zone_equip_zonemd(ldns_dnssec_zone *zone,
+		ldns_rr_list *new_rrs, ldns_key_list *key_list, int signflags);
 ldns_status
 dnssec_zone_equip_zonemd(ldns_dnssec_zone *zone,
 		ldns_rr_list *new_rrs, ldns_key_list *key_list, int signflags)

--- a/edns.c
+++ b/edns.c
@@ -73,21 +73,21 @@ ldns_edns_get_wireformat_buffer(const ldns_edns_option *edns)
 }
 
 /* write */
-void
+static void
 ldns_edns_set_size(ldns_edns_option *edns, size_t size)
 {
 	assert(edns != NULL);
 	edns->_size = size;
 }
 
-void
+static void
 ldns_edns_set_code(ldns_edns_option *edns, ldns_edns_option_code code)
 {
 	assert(edns != NULL);
 	edns->_code = code;
 }
 
-void
+static void
 ldns_edns_set_data(ldns_edns_option *edns, void *data)
 {
 	/* only copy the pointer */

--- a/packet.c
+++ b/packet.c
@@ -759,6 +759,8 @@ ldns_pkt_edns(const ldns_pkt *pkt)
 }
 
 ldns_edns_option_list*
+pkt_edns_data2edns_option_list(const ldns_rdf *edns_data);
+ldns_edns_option_list*
 pkt_edns_data2edns_option_list(const ldns_rdf *edns_data)
 {
 	size_t pos = 0;

--- a/rr.c
+++ b/rr.c
@@ -724,6 +724,10 @@ ldns_rr_new_frm_fp(ldns_rr **newrr, FILE *fp, uint32_t *ttl, ldns_rdf **origin, 
 ldns_status
 _ldns_rr_new_frm_fp_l_internal(ldns_rr **newrr, FILE *fp,
 		uint32_t *default_ttl, ldns_rdf **origin, ldns_rdf **prev,
+		int *line_nr, bool *explicit_ttl);
+ldns_status
+_ldns_rr_new_frm_fp_l_internal(ldns_rr **newrr, FILE *fp,
+		uint32_t *default_ttl, ldns_rdf **origin, ldns_rdf **prev,
 		int *line_nr, bool *explicit_ttl)
 {
 	char *line = NULL;

--- a/str2host.c
+++ b/str2host.c
@@ -2198,7 +2198,7 @@ static const size_t svcparam_key_defs_len = sizeof(svcparam_key_defs)
 /* svcparam_key2buffer_str() should actually be in host2str.c, but we need the
  * svcparam_key_defs for it and it is not an exposed symbol anyway.
  */
-ldns_status svcparam_key2buffer_str(ldns_buffer *output, uint16_t key)
+static ldns_status svcparam_key2buffer_str(ldns_buffer *output, uint16_t key)
 {
 	if (key <= LDNS_SVCPARAM_KEY_LAST_KEY)
 		ldns_buffer_write_string(output, svcparam_key_defs[key].str);

--- a/util.c
+++ b/util.c
@@ -317,6 +317,8 @@ ldns_serial_arithmetics_gmtime_r(int32_t time, time_t now, struct tm *result)
 #endif
 /* alias function because of previously used wrong spelling */
 struct tm *
+ldns_serial_arithmitics_gmtime_r(int32_t time, time_t now, struct tm *result);
+struct tm *
 ldns_serial_arithmitics_gmtime_r(int32_t time, time_t now, struct tm *result)
 {
 	return ldns_serial_arithmetics_gmtime_r(time, now, result);


### PR DESCRIPTION
This adds an ldns/internal.h C header, containing a copy of the function prototypes for internal functions not exposed in the API.

It effectively works around the following compilation error: error: no previous prototype for function [-Werror,-Wmissing-prototypes]

This header is not installed, and does not affect the API exposed.

Tested on FreeBSD/amd64 (14.0-CURRENT).

Note that this was performed on version 1.8.3, but it seems that it still applies in the same way in the `develop` branch.