### PR TITLE
Update declaration for function with no arguments

### DIFF
--- a/edns.c
+++ b/edns.c
@@ -167,7 +167,7 @@ ldns_edns_free(ldns_edns_option *edns)
 }
 
 ldns_edns_option_list*
-ldns_edns_option_list_new()
+ldns_edns_option_list_new(void)
 {
 	ldns_edns_option_list *option_list = LDNS_MALLOC(ldns_edns_option_list);
 	if(!option_list) {


### PR DESCRIPTION
With -Wstrict-prototypes clang warns that "a function declaration without a prototype is deprecated in all versions of C."