### PR TITLE
Optionally exclude ZONEMD RRs in ldns-compare-zone

### DIFF
--- a/ldns/zone.h
+++ b/ldns/zone.h
@@ -151,6 +151,21 @@ ldns_status ldns_zone_new_frm_fp(ldns_zone **z, FILE *fp, const ldns_rdf *origin
 ldns_status ldns_zone_new_frm_fp_l(ldns_zone **z, FILE *fp, const ldns_rdf *origin, uint32_t ttl, ldns_rr_class c, int *line_nr);
 
 /**
+ * Create a new zone from a file, keep track of the line numbering,
+ * filtering out the specified RR type
+ * \param[out] z the new zone
+ * \param[in] *fp the filepointer to use
+ * \param[in] *origin the zones' origin
+ * \param[in] ttl default ttl to use
+ * \param[in] c default class to use (IN)
+ * \param[out] line_nr used for error msg, to get to the line number
+ * \param[in] exc excluded RR type
+ *
+ * \return ldns_status mesg with an error or LDNS_STATUS_OK
+ */
+ldns_status ldns_zone_new_frm_fp_l_e(ldns_zone **z, FILE *fp, const ldns_rdf *origin, uint32_t ttl, ldns_rr_class c, int *line_nr, ldns_rr_type exc);
+
+/**
  * Frees the allocated memory for the zone, and the rr_list structure in it
  * \param[in] zone the zone to free
  */

--- a/zone.c
+++ b/zone.c
@@ -198,6 +198,13 @@ ldns_status
 ldns_zone_new_frm_fp_l(ldns_zone **z, FILE *fp, const ldns_rdf *origin,
 	uint32_t default_ttl, ldns_rr_class ATTR_UNUSED(c), int *line_nr)
 {
+	return ldns_zone_new_frm_fp_l_e(z, fp, origin, default_ttl, c, line_nr, 0);
+}
+
+ldns_status
+ldns_zone_new_frm_fp_l_e(ldns_zone **z, FILE *fp, const ldns_rdf *origin,
+	uint32_t default_ttl, ldns_rr_class ATTR_UNUSED(c), int *line_nr, ldns_rr_type exc)
+{
 	ldns_zone *newzone;
 	ldns_rr *rr, *prev_rr = NULL;
 	uint32_t my_ttl;
@@ -299,6 +306,11 @@ ldns_zone_new_frm_fp_l(ldns_zone **z, FILE *fp, const ldns_rdf *origin,
 				if (!my_origin) {
 					my_origin = ldns_rdf_clone(ldns_rr_owner(rr));
 				}
+				continue;
+			}
+			/* skip excluded RR type */
+			else if (ldns_rr_get_type(rr) == exc) {
+				ldns_rr_free(rr);
 				continue;
 			}
 			


### PR DESCRIPTION
As with `SOA`, `ZONEMD` resource records may not be meaningful when comparing zones (because of the only difference may be the `SOA` `SERIAL` value, leading to different `ZONEMD` RDATA).

This pull request:
* defines a new function `ldns_zone_new_frm_fp_l_e` to parse a zone excluding a specified RR type;
* adds a new `-Z` option to `ldns-compare-zone` to exclude ZONEMD RR type from zone comparison.

When setting `-Z`, the last argument to `ldns_zone_new_frm_fp_l_e` is set to `LDNS_RR_TYPE_ZONEMD` and this record type is ignored while reading the zone from file.

I know this change could have been implemented purely in `examples/ldns-compare-zones.c` (e.g. by creating a new empty `rr_list`, iterating over all the read RRs and only those with a type different from from `LDNS_RR_TYPE_ZONEMD`) but this seemed inefficient, especially for large zones.

The counterpart is this solution creates an additional "core" function in `zone.c`, for the sole purpose of this additional option. If this is deemed too obtrusive, I can fallback to the other alternative.

I am also aware that `ZONEMD` RRs can be filtered out using `ldns-read-zone -e ZONEMD` but this doubles the amount of parsing and pipes/redirections may not always be available (e. g. while using `ldns-compare-zone` in systemd `Exec*` directives).