### PR TITLE
keys.c: fix build with libressl >= 3.8.1

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -132,7 +132,7 @@ ldns_key_new_frm_engine(ldns_key **key, ENGINE *e, char *key_id, ldns_algorithm 
 }
 #endif
 
-#ifdef USE_GOST
+#if defined(USE_GOST) && !defined(OPENSSL_NO_ENGINE)
 /** store GOST engine reference loaded into OpenSSL library */
 ENGINE* ldns_gost_engine = NULL;
 


### PR DESCRIPTION
libressl >= 3.8.1 removed ENGINE support:

> ENGINE support was removed and OPENSSL_NO_ENGINE is set. In spite of this, some stub functions are provided to avoid patching some applications that do not honor OPENSSL_NO_ENGINE.

resulting in the following build failure with gost:

```
./keys.c:167:35: error: 'ENGINE_METHOD_ALL' undeclared (first use in this function)
  167 |         if(!ENGINE_set_default(e, ENGINE_METHOD_ALL)) {
      |                                   ^~~~~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/37cc05b78a7004caa1b45d896121f059a4f8ca00