### PR TITLE
python3 bindings: ldnsx.py "class resolver" fix

### DIFF
--- a/contrib/ldnsx/ldnsx.py
+++ b/contrib/ldnsx/ldnsx.py
@@ -216,7 +216,7 @@ class resolver:
 			self.drop_nameservers()
 			nm_list = ns.split(',')
 			nm_list = map(lambda s: s.strip(), nm_list)
-			nm_list = filter(lambda s: s != "", nm_list)
+			nm_list = list(filter(lambda s: s != "", nm_list))
 			nm_list.reverse()
 			for nm in nm_list:
 				self.add_nameserver(nm)


### PR DESCRIPTION
Imitating the example in the beginning of ldnsx.py results in error:

host:~/rpmbuild# python
Python 3.9.16 (main, Dec  8 2022, 00:00:00)
[GCC 11.3.1 20221121 (Red Hat 11.3.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ldnsx
>>> dir(ldnsx)
['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', '__version__', '_rr_types', 'calendar', 'get_rrs', 'isValidIP', 'ldns', 'packet', 'query', 'resolver', 'resource_record', 'secure_query', 'socket', 'sys', 'time', 'warnings']
>>> ldnsx.resolver("9.9.9.9").query("www.hole.fi", "A")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.9/site-packages/ldnsx.py", line 220, in __init__
    nm_list.reverse()
AttributeError: 'filter' object has no attribute 'reverse'
>>>

This patch fixes it, i.e. just add list( .. ) around the filter lambda.