### PR TITLE
const ldns_rdf * typemap fixes to support swig-4.2.0

### DIFF
--- a/contrib/python/ldns_rdf.i
+++ b/contrib/python/ldns_rdf.i
@@ -50,6 +50,7 @@
       SWIGTYPE_p_ldns_struct_rdf, SWIG_POINTER_OWN | 0));
 }
 
+#if SWIG_VERSION < 0x040200
 /*
  * Automatic conversion of const (ldns_rdf *) parameter from string.
  * Argument default value.
@@ -95,6 +96,51 @@
     SWIG_Python_str_DelForPy3($1_str); /* Is a empty macro for Python < 3. */
   }
 }
+
+#else
+/*
+ * Automatic conversion of const (ldns_rdf *) parameter from string.
+ * Argument default value.
+ */
+%typemap(arginit, noblock=1) const ldns_rdf *
+{
+  PyObject *$1_bytes = NULL;
+}
+
+/*
+ * Automatic conversion of const (ldns_rdf *) parameter from string.
+ * Preparation of arguments.
+ */
+%typemap(in, noblock=1) const ldns_rdf * (void* argp, $1_ltype tmp = 0, int res)
+{
+  if (Python_str_Check($input)) {
+    const char *$1_str = SWIG_PyUnicode_AsUTF8AndSize($input, NULL, &$1_bytes);
+    if ($1_str == NULL) {
+      %argument_fail(SWIG_TypeError, "char *", $symname, $argnum);
+    }
+    tmp = ldns_dname_new_frm_str($1_str);
+    if (tmp == NULL) {
+      %argument_fail(SWIG_TypeError, "char *", $symname, $argnum);
+    }
+    $1 = ($1_ltype) tmp;
+  } else {
+    res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_ldns_struct_rdf, 0 | 0);
+    if (!SWIG_IsOK(res)) {
+      %argument_fail(res, "ldns_rdf const *", $symname, $argnum);
+    }
+    $1 = ($1_ltype) argp;
+  }
+}
+
+/*
+ * Automatic conversion of const (ldns_rdf *) parameter from string.
+ * Freeing of allocated memory (it's a no op unless compiling for some older versions of the Python stable ABI).
+ */
+%typemap(freearg, noblock=1) const ldns_rdf *
+{
+  Py_XDECREF($1_bytes);
+}
+#endif
 
 %nodefaultctor ldns_struct_rdf; /* No default constructor. */
 %nodefaultdtor ldns_struct_rdf; /* No default destructor. */


### PR DESCRIPTION
SWIG_Python_str_AsChar needs to be replaced by SWIG_PyUnicode_AsUTF8AndSize. See https://github.com/swig/swig/commit/f89dd59d4b82ece899087682fdb86e94d2611513.

The patch leaves the typemap code unchanged for older versions of SWIG, hence swig-4.2.0 as well as older versions of SWIG can be used.