### PR TITLE
Don't rely on libcrypto returning static buffers

### DIFF
--- a/dnssec_sign.c
+++ b/dnssec_sign.c
@@ -332,6 +332,7 @@ ldns_rdf *
 ldns_sign_public_dsa(ldns_buffer *to_sign, DSA *key)
 {
 #ifdef USE_DSA
+	unsigned char md[EVP_MAX_MD_SIZE];
 	unsigned char *sha1_hash;
 	ldns_rdf *sigdata_rdf;
 	ldns_buffer *b64sig;
@@ -347,7 +348,7 @@ ldns_sign_public_dsa(ldns_buffer *to_sign, DSA *key)
 	}
 
 	sha1_hash = SHA1((unsigned char*)ldns_buffer_begin(to_sign),
-				  ldns_buffer_position(to_sign), NULL);
+				  ldns_buffer_position(to_sign), md);
 	if (!sha1_hash) {
 		ldns_buffer_free(b64sig);
 		return NULL;
@@ -571,6 +572,7 @@ ldns_sign_public_evp(ldns_buffer *to_sign,
 ldns_rdf *
 ldns_sign_public_rsasha1(ldns_buffer *to_sign, RSA *key)
 {
+	unsigned char md[EVP_MAX_MD_SIZE];
 	unsigned char *sha1_hash;
 	unsigned int siglen;
 	ldns_rdf *sigdata_rdf;
@@ -584,7 +586,7 @@ ldns_sign_public_rsasha1(ldns_buffer *to_sign, RSA *key)
 	}
 
 	sha1_hash = SHA1((unsigned char*)ldns_buffer_begin(to_sign),
-				  ldns_buffer_position(to_sign), NULL);
+				  ldns_buffer_position(to_sign), md);
 	if (!sha1_hash) {
 		ldns_buffer_free(b64sig);
 		return NULL;
@@ -607,6 +609,7 @@ ldns_sign_public_rsasha1(ldns_buffer *to_sign, RSA *key)
 ldns_rdf *
 ldns_sign_public_rsamd5(ldns_buffer *to_sign, RSA *key)
 {
+	unsigned char md[EVP_MAX_MD_SIZE];
 	unsigned char *md5_hash;
 	unsigned int siglen;
 	ldns_rdf *sigdata_rdf;
@@ -618,7 +621,7 @@ ldns_sign_public_rsamd5(ldns_buffer *to_sign, RSA *key)
 	}
 
 	md5_hash = MD5((unsigned char*)ldns_buffer_begin(to_sign),
-				ldns_buffer_position(to_sign), NULL);
+				ldns_buffer_position(to_sign), md);
 	if (!md5_hash) {
 		ldns_buffer_free(b64sig);
 		return NULL;


### PR DESCRIPTION
ldns is one of very few applications relying on being able to pass NULL as last argument to the one-step hashing functions. BoringSSL has removed this functionality in 2017 [1] and LibreSSL 4.0 will do the same. Applications can pass in a correctly-sized buffer on the stack.

[1]: https://boringssl-review.googlesource.com/14528