### PR TITLE
Address several issues with the ultimate goal being to fix Coverity cited problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /compat/strlcpy.lo
 /compat/timegm.o
 /compat/timegm.lo
+/compile
 /config.guess
 /config.h
 /config.log
@@ -158,10 +159,12 @@
 /ldns/config.h
 /ldns/config.h.in
 /ldns/net.h
+/ldns/stamp-h1
 /ldns/util.h
 /ldns_wrapper.lo
 /ldns_wrapper.o
 /lib
+/libdns.doxygen
 /libldns.la
 /libtool
 /linktest
@@ -170,6 +173,7 @@
 /ltmain.sh
 /m4/lt*.m4
 /m4/libtool.m4
+/missing
 /net.lo
 /net.o
 /packaging/ldns-config

--- a/README.snapshots
+++ b/README.snapshots
@@ -3,6 +3,6 @@ ldns - snapshot releases
 Snapshot releases are not official released. They can be released to
 interested parties for development.
 
-Snapshots can be recognized from the date in the the tar file name.
+Snapshots can be recognized from the date in the tar file name.
 
 They should not be used for packaging in distributions.

--- a/dane.c
+++ b/dane.c
@@ -625,10 +625,10 @@ ldns_dane_match_any_cert_with_data(STACK_OF(X509)* chain,
 		ldns_rdf* data, bool ca)
 {
 	ldns_status s = LDNS_STATUS_DANE_TLSA_DID_NOT_MATCH;
-	size_t n, i;
+	int n, i;
 	X509* cert;
 
-	n = (size_t)sk_X509_num(chain);
+	n = sk_X509_num(chain);
 	for (i = 0; i < n; i++) {
 		cert = sk_X509_pop(chain);
 		if (! cert) {

--- a/dnssec.c
+++ b/dnssec.c
@@ -959,7 +959,7 @@ ldns_create_nsec(ldns_rdf *cur_owner, ldns_rdf *next_owner, ldns_rr_list *rrs)
 {
 	/* we do not do any check here - garbage in, garbage out */
 
-	/* the the start and end names - get the type from the
+	/* the start and end names - get the type from the
 	 * before rrlist */
 
 	/* inefficient, just give it a name, a next name, and a list of rrs */

--- a/dnssec.c
+++ b/dnssec.c
@@ -1836,8 +1836,10 @@ ldns_convert_dsa_rrsig_rdf2asn1(ldns_buffer *target_buffer,
 		return LDNS_STATUS_MEM_ERR;
 	}
 # ifdef HAVE_DSA_SIG_SET0
-       if (! DSA_SIG_set0(dsasig, R, S))
-	       return LDNS_STATUS_SSL_ERR;
+	if (! DSA_SIG_set0(dsasig, R, S)) {
+		DSA_SIG_free(dsasig);
+		return LDNS_STATUS_SSL_ERR;
+	}
 # else
 	dsasig->r = R;
 	dsasig->s = S;

--- a/ldns/parse.h
+++ b/ldns/parse.h
@@ -131,7 +131,7 @@ ssize_t ldns_bget_token(ldns_buffer *b, char *token, const char *delim, size_t l
  * \param[in] k_del keyword delimiter 
  * \param[out] data the data found 
  * \param[in] d_del the data delimiter
- * \param[in] data_limit maximum size the the data buffer
+ * \param[in] data_limit maximum size the data buffer
  * \return the number of character read
  */
 ssize_t ldns_fget_keyword_data(FILE *f, const char *keyword, const char *k_del, char *data, const char *d_del, size_t data_limit);
@@ -144,7 +144,7 @@ ssize_t ldns_fget_keyword_data(FILE *f, const char *keyword, const char *k_del, 
  * \param[in] k_del keyword delimiter 
  * \param[out] data the data found 
  * \param[in] d_del the data delimiter
- * \param[in] data_limit maximum size the the data buffer
+ * \param[in] data_limit maximum size the data buffer
  * \param[in] line_nr pointer to an integer containing the current line number (for
 debugging purposes)
  * \return the number of character read
@@ -159,7 +159,7 @@ ssize_t ldns_fget_keyword_data_l(FILE *f, const char *keyword, const char *k_del
  * \param[in] k_del keyword delimiter 
  * \param[out] data the data found 
  * \param[in] d_del the data delimiter
- * \param[in] data_limit maximum size the the data buffer
+ * \param[in] data_limit maximum size the data buffer
  * \return the number of character read
  */
 ssize_t ldns_bget_keyword_data(ldns_buffer *b, const char *keyword, const char *k_del, char *data, const char *d_del, size_t data_limit);

--- a/ldns/radix.h
+++ b/ldns/radix.h
@@ -74,7 +74,7 @@ struct ldns_radix_node_t {
 	void* data;
 	/** Parent node. */
 	ldns_radix_node_t* parent;
-	/** Index in the the parent node select edge array. */
+	/** Index in the parent node select edge array. */
 	uint8_t parent_index;
 	/** Length of the array. */
 	uint16_t len;

--- a/ldns/rdata.h
+++ b/ldns/rdata.h
@@ -243,7 +243,7 @@ size_t ldns_rdf_size(const ldns_rdf *rd);
 
 /**
  * returns the type of the rdf. We need to insert _get_
- * here to prevent conflict the the rdf_type TYPE.
+ * here to prevent conflict the rdf_type TYPE.
  * \param[in] *rd the rdf to read from
  * \return ldns_rdf_type with the type
  */

--- a/lua/rns-specs
+++ b/lua/rns-specs
@@ -85,7 +85,7 @@ freedom in the packet mangling. (ghe ghe :-) )
 
 To keep matters interesting some sort of randomness is required in some
 step, otherwise each packet is mangled in the same way. Also this
-randomness together with the Lua script needs to be logged so the the 
+randomness together with the Lua script needs to be logged so the 
 actual mangling can be replayed.
 
 :Packet Mangling: address the different elements:

--- a/pcat/pcat-diff.1
+++ b/pcat/pcat-diff.1
@@ -9,7 +9,7 @@ pcat-diff \- show the difference between two pcat files.
 
 .SH DESCRIPTION
 \fBpcat-diff\fR reads in two pcat files and show the differences
-between the them.
+between them.
 Its output is another pcat stream which can then be interpreted by
 pcat-print.
 


### PR DESCRIPTION
- Update `.gitignore` to ignore more build generated files.
- Fix typos (`the the` -> `the`).
- Fix a memory leak.
- Fix a bad type/potential unsigned integer overflow issue.