### PR TITLE
Openssl no engine improved support

### DIFF
--- a/examples/ldns-nsec3-hash.c
+++ b/examples/ldns-nsec3-hash.c
@@ -18,7 +18,6 @@
 
 #ifdef HAVE_SSL
 #include <openssl/conf.h>
-#include <openssl/engine.h>
 #endif /* HAVE_SSL */
 
 #define MAX_FILENAME_LEN 250

--- a/examples/ldns-signzone.c
+++ b/examples/ldns-signzone.c
@@ -22,8 +22,12 @@
 #include <ldns/keys.h>
 
 #include <openssl/conf.h>
-#ifndef OPENSSL_NO_ENGINE
+#if defined(HAVE_OPENSSL_ENGINE_H) && !defined(OPENSSL_NO_ENGINE)
 #include <openssl/engine.h>
+#else
+#  ifndef OPENSSL_NO_ENGINE
+#  define OPENSSL_NO_ENGINE
+#  endif
 #endif
 #include <openssl/err.h>
 

--- a/keys.c
+++ b/keys.c
@@ -120,16 +120,12 @@ ldns_key_new_frm_engine(ldns_key **key, ENGINE *e, char *key_id, ldns_algorithm 
 	k = ldns_key_new();
         if(!k) return LDNS_STATUS_MEM_ERR;
 #ifndef S_SPLINT_S
-	k->_key.key = ENGINE_load_private_key(e, key_id, UI_OpenSSL(), NULL);
-        if(!k->_key.key) {
-                ldns_key_free(k);
-                return LDNS_STATUS_ERR;
-        }
 	ldns_key_set_algorithm(k, (ldns_signing_algorithm) alg);
+	k->_key.key = ENGINE_load_private_key(e, key_id, UI_OpenSSL(), NULL);
 	if (!k->_key.key) {
                 ldns_key_free(k);
 		return LDNS_STATUS_ENGINE_KEY_NOT_LOADED;
-	} 
+	}
 #endif /* splint */
 	*key = k;
 	return LDNS_STATUS_OK;

--- a/keys.c
+++ b/keys.c
@@ -23,8 +23,12 @@
 #ifdef USE_DSA
 #include <openssl/dsa.h>
 #endif
-#ifndef OPENSSL_NO_ENGINE
+#if defined(HAVE_OPENSSL_ENGINE_H) && !defined(OPENSSL_NO_ENGINE)
 #include <openssl/engine.h>
+#else
+#  ifndef OPENSSL_NO_ENGINE
+#  define OPENSSL_NO_ENGINE
+#  endif
 #endif
 #endif /* HAVE_SSL */
 


### PR DESCRIPTION
Extend checks when openssl engine support is missing. Fix build of examples/ldns-nsec3-hash in that case. Clean a bit frm_engine function.