### PR TITLE
Make IPv6 DNSSEC tracing work, and revert to previous behaviour otherwise

### DIFF
--- a/drill/securetrace.c
+++ b/drill/securetrace.c
@@ -291,7 +291,12 @@ do_secure_trace(ldns_resolver *local_res, ldns_rdf *name, ldns_rr_type t,
 				/* trust glue? */
 				new_ns_addr = NULL;
 				if (ldns_dname_is_subdomain(pop, labels[i])) {
-					new_ns_addr = ldns_pkt_rr_list_by_name_and_type(local_p, pop, LDNS_RR_TYPE_A, LDNS_SECTION_ADDITIONAL);
+					if (ldns_resolver_ip6(res) == LDNS_RESOLV_INET6) {
+						new_ns_addr = ldns_pkt_rr_list_by_name_and_type(local_p, pop, LDNS_RR_TYPE_AAAA, LDNS_SECTION_ADDITIONAL);
+					} else {
+						/* If IPv4 is specified, or no IP version is specified, default to A record and use IPv4 */
+						new_ns_addr = ldns_pkt_rr_list_by_name_and_type(local_p, pop, LDNS_RR_TYPE_A, LDNS_SECTION_ADDITIONAL);
+					}
 				}
 				if (!new_ns_addr || ldns_rr_list_rr_count(new_ns_addr) == 0) {
 					new_ns_addr = ldns_get_rr_list_addr_by_name(res, pop, c, 0);


### PR DESCRIPTION
IPv6 DNSSEC trace ("secure trace") does not currently work because only A records are permitted for NSs that are used to trace down from the root. AAAA records are needed for that. Currently an IPv6 DNSSEC trace fails after asking the root, because drill has no valid NSs to continue with.

With this patch, if drill is executed _without_ "-6", the previous behavior continues, with only A records being used.
This is not optimal because without the "-4" or "-6" command line parameters, drill is supposed to randomly use either v4 or v6, as indicated by the `LDNS_RR_TYPE_ANY` default for `qfamily`, but there is no `LDNS_RR_TYPE_A_AND_AAAA`  RR descriptor and I don't know how to join two results of the `ldns_rr_list` data type.
Thanks to Felipe Barbosa for reviewing and input.