### PR TITLE
Make ldns_calc_keytag() available for CDNSKEY RR

### DIFF
--- a/dnssec.c
+++ b/dnssec.c
@@ -285,6 +285,7 @@ ldns_calc_keytag(const ldns_rr *key)
 	}
 
 	if (ldns_rr_get_type(key) != LDNS_RR_TYPE_DNSKEY &&
+	    ldns_rr_get_type(key) != LDNS_RR_TYPE_CDNSKEY &&
 	    ldns_rr_get_type(key) != LDNS_RR_TYPE_KEY
 	    ) {
 		return 0;

--- a/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.c
+++ b/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.c
@@ -62,6 +62,12 @@ check_ldns_calc_keytag(void)
 		result = LDNS_STATUS_ERR;
 	}
 
+	key_str = "jelte.nlnetlabs.nl. IN CDNSKEY 256 3 5 AQOraLfzarHAlFskVGwAGnX0LRjlcOiO6y5WM4Kz+QvZ9vX28h4lOvnf d5tkxnZm7ERLTAJoFq+1w/wl7VXs2Isz75BSZ7LQh3OT2xXnS6VT5ZxX ko/UCOdoGiKZZ63jHZ0jNSTCYy8+5rfvwRD8s3gGuErp5KcHg3V8VLUK SDNNEQ==";
+	expected_keytag = 42860;
+	if (check_ldns_calc_keytag_part(key_str, expected_keytag) != LDNS_STATUS_OK) {
+		result = LDNS_STATUS_ERR;
+	}
+
 /* template for adding extra keys
 	key_str = "";
 	expected_keytag = ;


### PR DESCRIPTION
Initial work copied from https://github.com/NLnetLabs/ldns/pull/187, which was inadvertently closed when its author deleted his GitHub account.

Original PR description:

> Hi, while working on CDS/CDNSKEY in Zonemaster I realized LDNS does not allow calling ldns_calc_keytag() on a CDNSKEY resource record (which is [identical to a DNSKEY resource record](https://www.rfc-editor.org/rfc/rfc7344#section-3.2)).