### PR TITLE
Make ldns_key_rr2ds() available for CDNSKEY RR

### DIFF
--- a/dnssec.c
+++ b/dnssec.c
@@ -518,7 +518,8 @@ ldns_key_rr2ds(const ldns_rr *key, ldns_hash h)
 	const EVP_MD* md = NULL;
 #endif
 
-	if (ldns_rr_get_type(key) != LDNS_RR_TYPE_DNSKEY) {
+	if (ldns_rr_get_type(key) != LDNS_RR_TYPE_DNSKEY &&
+	    ldns_rr_get_type(key) != LDNS_RR_TYPE_CDNSKEY) {
 		return NULL;
 	}
 

--- a/dnssec.c
+++ b/dnssec.c
@@ -285,6 +285,7 @@ ldns_calc_keytag(const ldns_rr *key)
 	}
 
 	if (ldns_rr_get_type(key) != LDNS_RR_TYPE_DNSKEY &&
+	    ldns_rr_get_type(key) != LDNS_RR_TYPE_CDNSKEY &&
 	    ldns_rr_get_type(key) != LDNS_RR_TYPE_KEY
 	    ) {
 		return 0;

--- a/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.c
+++ b/test/12-unit-tests-dnssec.tpkg/12-unit-tests-dnssec.c
@@ -62,6 +62,12 @@ check_ldns_calc_keytag(void)
 		result = LDNS_STATUS_ERR;
 	}
 
+	key_str = "jelte.nlnetlabs.nl. IN CDNSKEY 256 3 5 AQOraLfzarHAlFskVGwAGnX0LRjlcOiO6y5WM4Kz+QvZ9vX28h4lOvnf d5tkxnZm7ERLTAJoFq+1w/wl7VXs2Isz75BSZ7LQh3OT2xXnS6VT5ZxX ko/UCOdoGiKZZ63jHZ0jNSTCYy8+5rfvwRD8s3gGuErp5KcHg3V8VLUK SDNNEQ==";
+	expected_keytag = 42860;
+	if (check_ldns_calc_keytag_part(key_str, expected_keytag) != LDNS_STATUS_OK) {
+		result = LDNS_STATUS_ERR;
+	}
+
 /* template for adding extra keys
 	key_str = "";
 	expected_keytag = ;


### PR DESCRIPTION
Hi, similar to #246, this PR proposes to extend `ldns_key_rr2ds()` to support the CDNSKEY resource record.

Depends (based) on #246. You can exclude commit aeaf02e754e25c0d0cba43c9fe67f38d29b0f5c2 for easier reviewing of this PR.

PS: I couldn't find any unitary test for this method in the `test` directory, so this PR is **untested** at the moment. Please feel free to provide additional changes in that regard.