### PR TITLE
Updates to ldns_is_rrset()

### DIFF
--- a/ldns/rr.h
+++ b/ldns/rr.h
@@ -725,6 +725,13 @@ bool ldns_rr_list_contains_rr(const ldns_rr_list *rr_list, const ldns_rr *rr);
 bool ldns_is_rrset(const ldns_rr_list *rr_list);
 
 /**
+ * checks if an rr_list is a rrset, including checking for TTL.
+ * \param[in] rr_list the rr_list to check
+ * \return true if it is an rrset otherwise false
+ */
+bool ldns_is_rrset_strict(const ldns_rr_list *rr_list);
+
+/**
  * pushes an rr to an rrset (which really are rr_list's).
  * \param[in] *rr_list the rrset to push the rr to
  * \param[in] *rr the rr to push

--- a/rr.c
+++ b/rr.c
@@ -1264,6 +1264,7 @@ ldns_is_rrset(const ldns_rr_list *rr_list)
 {
 	ldns_rr_type t;
 	ldns_rr_class c;
+	uint32_t l;
 	ldns_rdf *o;
 	ldns_rr *tmp;
 	size_t i;
@@ -1276,6 +1277,7 @@ ldns_is_rrset(const ldns_rr_list *rr_list)
 
 	t = ldns_rr_get_type(tmp);
 	c = ldns_rr_get_class(tmp);
+	l = ldns_rr_ttl(tmp);
 	o = ldns_rr_owner(tmp);
 
 	/* compare these with the rest of the rr_list, start with 1 */
@@ -1287,7 +1289,10 @@ ldns_is_rrset(const ldns_rr_list *rr_list)
 		if (c != ldns_rr_get_class(tmp)) {
 			return false;
 		}
-		if (ldns_rdf_compare(o, ldns_rr_owner(tmp)) != 0) {
+		if (l != ldns_rr_ttl(tmp)) {
+			return false;
+		}
+		if (ldns_dname_compare(o, ldns_rr_owner(tmp)) != 0) {
 			return false;
 		}
 	}

--- a/rr.c
+++ b/rr.c
@@ -1264,6 +1264,41 @@ ldns_is_rrset(const ldns_rr_list *rr_list)
 {
 	ldns_rr_type t;
 	ldns_rr_class c;
+	ldns_rdf *o;
+	ldns_rr *tmp;
+	size_t i;
+
+	if (!rr_list || ldns_rr_list_rr_count(rr_list) == 0) {
+		return false;
+	}
+
+	tmp = ldns_rr_list_rr(rr_list, 0);
+
+	t = ldns_rr_get_type(tmp);
+	c = ldns_rr_get_class(tmp);
+	o = ldns_rr_owner(tmp);
+
+	/* compare these with the rest of the rr_list, start with 1 */
+	for (i = 1; i < ldns_rr_list_rr_count(rr_list); i++) {
+		tmp = ldns_rr_list_rr(rr_list, i);
+		if (t != ldns_rr_get_type(tmp)) {
+			return false;
+		}
+		if (c != ldns_rr_get_class(tmp)) {
+			return false;
+		}
+		if (ldns_dname_compare(o, ldns_rr_owner(tmp)) != 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool
+ldns_is_rrset_strict(const ldns_rr_list *rr_list)
+{
+	ldns_rr_type t;
+	ldns_rr_class c;
 	uint32_t l;
 	ldns_rdf *o;
 	ldns_rr *tmp;


### PR DESCRIPTION
This PR proposes two updates to `ldns_is_rrset()`: 
- to take into account TTL _--> see [RFC2181, Section 5.2](https://www.rfc-editor.org/rfc/rfc2181.html#section-5.2) and [RFC9499, Section 5](https://www.rfc-editor.org/rfc/rfc9499#section-5)_
- do case insensitive comparison of owner names, using function `ldns_dname_compare()` _--> I couldn't find a proper reference from the same RFCs regarding RRsets specifically, but from a practical point on view it seems appropriate. Also see [RFC4343](https://www.rfc-editor.org/rfc/rfc4343)._

PS: I couldn't find any unitary test for this method in the test directory, so this PR is **untested** at the moment. Please feel free to provide additional changes in that regard.