### PR TITLE
Use SWIG_AppendOutput to support swig 4.3

### DIFF
--- a/contrib/python/ldns_buffer.i
+++ b/contrib/python/ldns_buffer.i
@@ -45,7 +45,7 @@
 /* Result generation, appends (ldns_buffer *) after the result. */
 %typemap(argout, noblock=1) (ldns_buffer **)
 {
-  $result = SWIG_Python_AppendOutput($result,
+  $result = SWIG_AppendOutput($result,
      SWIG_NewPointerObj(SWIG_as_voidptr($1_buf),
        SWIGTYPE_p_ldns_struct_buffer, SWIG_POINTER_OWN | 0));
 }

--- a/contrib/python/ldns_key.i
+++ b/contrib/python/ldns_key.i
@@ -38,7 +38,7 @@
 /* result generation */
 %typemap(argout,noblock=1) (ldns_key **)
 {
-  $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr($1_key), SWIGTYPE_p_ldns_struct_key, SWIG_POINTER_OWN |  0 ));
+  $result = SWIG_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr($1_key), SWIGTYPE_p_ldns_struct_key, SWIG_POINTER_OWN |  0 ));
 }
 
 %typemap(argout) ldns_rdf *r "Py_INCREF($input);"

--- a/contrib/python/ldns_packet.i
+++ b/contrib/python/ldns_packet.i
@@ -45,7 +45,7 @@
 /* Result generation, appends (ldns_pkt *) after the result. */
 %typemap(argout,noblock=1) (ldns_pkt **)
 {
-  $result = SWIG_Python_AppendOutput($result,
+  $result = SWIG_AppendOutput($result,
     SWIG_NewPointerObj(SWIG_as_voidptr($1_pkt),
       SWIGTYPE_p_ldns_struct_pkt, SWIG_POINTER_OWN |  0 ));
 }

--- a/contrib/python/ldns_rdf.i
+++ b/contrib/python/ldns_rdf.i
@@ -45,7 +45,7 @@
 /* Result generation, appends (ldns_rdf *) after the result. */
 %typemap(argout, noblock=1) (ldns_rdf **)
 {
-  $result = SWIG_Python_AppendOutput($result,
+  $result = SWIG_AppendOutput($result,
     SWIG_NewPointerObj(SWIG_as_voidptr($1_rdf),
       SWIGTYPE_p_ldns_struct_rdf, SWIG_POINTER_OWN | 0));
 }

--- a/contrib/python/ldns_resolver.i
+++ b/contrib/python/ldns_resolver.i
@@ -45,7 +45,7 @@
 /* Result generation, appends (ldns_resolver *) after the result. */
 %typemap(argout,noblock=1) (ldns_resolver **r)
 {
-  $result = SWIG_Python_AppendOutput($result,
+  $result = SWIG_AppendOutput($result,
     SWIG_NewPointerObj(SWIG_as_voidptr($1_res),
       SWIGTYPE_p_ldns_struct_resolver, SWIG_POINTER_OWN |  0 ));
 }

--- a/contrib/python/ldns_rr.i
+++ b/contrib/python/ldns_rr.i
@@ -45,7 +45,7 @@
 /* Result generation, appends (ldns_rr *) after the result. */
 %typemap(argout, noblock=1) (ldns_rr **) 
 {
-  $result = SWIG_Python_AppendOutput($result,
+  $result = SWIG_AppendOutput($result,
     SWIG_NewPointerObj(SWIG_as_voidptr($1_rr),
       SWIGTYPE_p_ldns_struct_rr, SWIG_POINTER_OWN |  0 ));
 }

--- a/contrib/python/ldns_zone.i
+++ b/contrib/python/ldns_zone.i
@@ -39,7 +39,7 @@
 /* result generation */
 %typemap(argout,noblock=1) (ldns_zone **)
 {
- $result = SWIG_Python_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr($1_zone), SWIGTYPE_p_ldns_struct_zone, SWIG_POINTER_OWN |  0 ));
+ $result = SWIG_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr($1_zone), SWIGTYPE_p_ldns_struct_zone, SWIG_POINTER_OWN |  0 ));
 }
 
 %nodefaultctor ldns_struct_zone; //no default constructor & destructor


### PR DESCRIPTION
Swig has changed language specific AppendOutput functions. But helper macro SWIG_AppendOutput remains unchanged. Use that everywhere instead of SWIG_Python_AppendOutput, which would require one extra parameter since swig 4.3.0.

https://github.com/swig/swig/blob/v4.3.0/CHANGES.current#L376 https://github.com/swig/swig/issues/2905