### PR TITLE
Draft: OpenSSL 3

### DIFF
--- a/ldns/dnssec.h
+++ b/ldns/dnssec.h
@@ -38,6 +38,10 @@
 extern "C" {
 #endif
 
+#if LDNS_BUILD_CONFIG_HAVE_SSL && !defined(OSSL_DEPRECATEDIN_3_0)
+#define OSSL_DEPRECATEDIN_3_0
+#endif
+
 #define LDNS_MAX_KEYLEN		2048
 #define LDNS_DNSSEC_KEYPROTO	3
 /* default time before sigs expire */
@@ -128,6 +132,8 @@ uint16_t ldns_calc_keytag(const ldns_rr *key);
 uint16_t ldns_calc_keytag_raw(const uint8_t* key, size_t keysize);
 
 #if LDNS_BUILD_CONFIG_HAVE_SSL
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * converts a buffer holding key material to a DSA key in openssl.
  *
@@ -135,6 +141,8 @@ uint16_t ldns_calc_keytag_raw(const uint8_t* key, size_t keysize);
  * \return a DSA * structure with the key material
  */
 DSA *ldns_key_buf2dsa(const ldns_buffer *key);
+
+OSSL_DEPRECATEDIN_3_0
 /**
  * Like ldns_key_buf2dsa, but uses raw buffer.
  * \param[in] key the uncompressed wireformat of the key.
@@ -142,6 +150,25 @@ DSA *ldns_key_buf2dsa(const ldns_buffer *key);
  * \return a DSA * structure with the key material
  */
 DSA *ldns_key_buf2dsa_raw(const unsigned char* key, size_t len);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+/**
+ * converts a buffer holding DSA key material to an EVP_PKEY key in openssl.
+ *
+ * \param[in] key the key to convert
+ * \return an EVP_PKEY * structure with the key material
+ */
+EVP_PKEY *ldns_dsa2pkey(const ldns_buffer *key);
+
+/**
+ * Like ldns_dsa2pkey, but uses raw buffer.
+ * \param[in] key the uncompressed wireformat of the key.
+ * \param[in] len length of key data
+ * \return an EVP_PKEY * structure with the key material
+ */
+EVP_PKEY *ldns_dsa2pkey_raw(const unsigned char* key, size_t len);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
 
 /**
  * Utility function to calculate hash using generic EVP_MD pointer.
@@ -194,6 +221,8 @@ EVP_PKEY* ldns_ed4482pkey_raw(const unsigned char* key, size_t keylen);
 #endif /* LDNS_BUILD_CONFIG_HAVE_SSL */
 
 #if LDNS_BUILD_CONFIG_HAVE_SSL
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * converts a buffer holding key material to a RSA key in openssl.
  *
@@ -202,6 +231,7 @@ EVP_PKEY* ldns_ed4482pkey_raw(const unsigned char* key, size_t keylen);
  */
 RSA *ldns_key_buf2rsa(const ldns_buffer *key);
 
+OSSL_DEPRECATEDIN_3_0
 /**
  * Like ldns_key_buf2rsa, but uses raw buffer.
  * \param[in] key the uncompressed wireformat of the key.
@@ -209,6 +239,25 @@ RSA *ldns_key_buf2rsa(const ldns_buffer *key);
  * \return a RSA * structure with the key material
  */
 RSA *ldns_key_buf2rsa_raw(const unsigned char* key, size_t len);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
+
+# if OPENSSL_VERSION_NUMBER >= 0x30000000L
+/**
+ * converts a buffer holding RSA key material to an EVP_PKEY key in openssl.
+ *
+ * \param[in] key the key to convert
+ * \return an EVP_PKEY * structure with the key material
+ */
+EVP_PKEY *ldns_rsa2pkey(const ldns_buffer *key);
+
+/**
+ * Like ldns_rsa2pkey, but uses raw buffer.
+ * \param[in] key the uncompressed wireformat of the key.
+ * \param[in] len length of key data
+ * \return an EVP_PKEY * structure with the key material
+ */
+EVP_PKEY *ldns_rsa2pkey_raw(const unsigned char* key, size_t len);
+# endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
 #endif /* LDNS_BUILD_CONFIG_HAVE_SSL */
 
 /** 

--- a/ldns/dnssec_sign.h
+++ b/ldns/dnssec_sign.h
@@ -47,6 +47,8 @@ ldns_sign_public_buffer(ldns_buffer *sign_buf, ldns_key *key);
 ldns_rr_list *ldns_sign_public(ldns_rr_list *rrset, ldns_key_list *keys);
 
 #if LDNS_BUILD_CONFIG_HAVE_SSL
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * Sign a buffer with the DSA key (hash with SHA1)
  *
@@ -55,7 +57,7 @@ ldns_rr_list *ldns_sign_public(ldns_rr_list *rrset, ldns_key_list *keys);
  * \return a ldns_rdf for the RRSIG ldns_rr
  */
 ldns_rdf *ldns_sign_public_dsa(ldns_buffer *to_sign, DSA *key);
-
+#endif /* OPENSSL_NO_DEPRECATED_3_0 */
 /**
  * Sign data with EVP (general method for different algorithms)
  *
@@ -70,6 +72,8 @@ ldns_rdf *ldns_sign_public_evp(ldns_buffer *to_sign,
 						 EVP_PKEY *key,
 						 const EVP_MD *digest_type);
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * Sign a buffer with the RSA key (hash with SHA1)
  * \param[in] to_sign buffer with the data
@@ -78,6 +82,7 @@ ldns_rdf *ldns_sign_public_evp(ldns_buffer *to_sign,
  */
 ldns_rdf *ldns_sign_public_rsasha1(ldns_buffer *to_sign, RSA *key);
 
+OSSL_DEPRECATEDIN_3_0
 /**
  * Sign a buffer with the RSA key (hash with MD5)
  * \param[in] to_sign buffer with the data
@@ -85,6 +90,7 @@ ldns_rdf *ldns_sign_public_rsasha1(ldns_buffer *to_sign, RSA *key);
  * \return a ldns_rdf with the signed data
  */
 ldns_rdf *ldns_sign_public_rsamd5(ldns_buffer *to_sign, RSA *key);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 #endif /* LDNS_BUILD_CONFIG_HAVE_SSL */
 
 /**

--- a/ldns/keys.h
+++ b/ldns/keys.h
@@ -32,6 +32,10 @@
 extern "C" {
 #endif
 
+#if LDNS_BUILD_CONFIG_HAVE_SSL && !defined(OSSL_DEPRECATEDIN_3_0)
+#define OSSL_DEPRECATEDIN_3_0
+#endif
+
 extern ldns_lookup_table ldns_signing_algorithms[];
 
 #define LDNS_KEY_ZONE_KEY 0x0100   /* rfc 4034 */
@@ -236,7 +240,27 @@ ldns_status ldns_key_new_frm_fp_l(ldns_key **k, FILE *fp, int *line_nr);
  */
 ldns_status ldns_key_new_frm_engine(ldns_key **key, ENGINE *e, char *key_id, ldns_algorithm a);
 
+# if OPENSSL_VERSION_NUMBER >= 0x30000000L
+/**
+ * frm_fp helper function. This function parses the
+ * remainder of the (RSA) priv. key file generated from bind9
+ * \param[in] fp the file to parse
+ * \return NULL on failure otherwise an EVP_PKEY structure
+ */
+EVP_PKEY *ldns_pkey_new_frm_fp_rsa(FILE *fp);
 
+/**
+ * frm_fp helper function. This function parses the
+ * remainder of the (RSA) priv. key file generated from bind9
+ * \param[in] fp the file to parse
+ * \param[in] line_nr pointer to an integer containing the current line number (for debugging purposes)
+ * \return NULL on failure otherwise an EVP_PKEY structure
+ */
+EVP_PKEY *ldns_pkey_new_frm_fp_rsa_l(FILE *fp, int *line_nr);
+# endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * frm_fp helper function. This function parses the
  * remainder of the (RSA) priv. key file generated from bind9
@@ -245,6 +269,7 @@ ldns_status ldns_key_new_frm_engine(ldns_key **key, ENGINE *e, char *key_id, ldn
  */
 RSA *ldns_key_new_frm_fp_rsa(FILE *fp);
 
+OSSL_DEPRECATEDIN_3_0
 /**
  * frm_fp helper function. This function parses the
  * remainder of the (RSA) priv. key file generated from bind9
@@ -253,25 +278,49 @@ RSA *ldns_key_new_frm_fp_rsa(FILE *fp);
  * \return NULL on failure otherwise a RSA structure
  */
 RSA *ldns_key_new_frm_fp_rsa_l(FILE *fp, int *line_nr);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 
 # if LDNS_BUILD_CONFIG_USE_DSA
+#  if OPENSSL_VERSION_NUMBER >= 0x30000000L
 /**
  * frm_fp helper function. This function parses the
  * remainder of the (DSA) priv. key file
  * \param[in] fp the file to parse
- * \return NULL on failure otherwise a RSA structure
+ * \return NULL on failure otherwise an EVP_PKEY structure
  */
-DSA *ldns_key_new_frm_fp_dsa(FILE *fp);
+EVP_PKEY *ldns_pkey_new_frm_fp_dsa(FILE *fp);
 
 /**
  * frm_fp helper function. This function parses the
  * remainder of the (DSA) priv. key file
  * \param[in] fp the file to parse
  * \param[in] line_nr pointer to an integer containing the current line number (for debugging purposes)
- * \return NULL on failure otherwise a RSA structure
+ * \return NULL on failure otherwise an EVP_PKEY structure
+ */
+EVP_PKEY *ldns_pkey_new_frm_fp_dsa_l(FILE *fp, int *line_nr);
+#  endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
+/**
+ * frm_fp helper function. This function parses the
+ * remainder of the (DSA) priv. key file
+ * \param[in] fp the file to parse
+ * \return NULL on failure otherwise a DSA structure
+ */
+DSA *ldns_key_new_frm_fp_dsa(FILE *fp);
+
+OSSL_DEPRECATEDIN_3_0
+/**
+ * frm_fp helper function. This function parses the
+ * remainder of the (DSA) priv. key file
+ * \param[in] fp the file to parse
+ * \param[in] line_nr pointer to an integer containing the current line number (for debugging purposes)
+ * \return NULL on failure otherwise a DSA structure
  */
 DSA *ldns_key_new_frm_fp_dsa_l(FILE *fp, int *line_nr);
+#  endif /* OPENSSL_NO_DEPRECATED_3_0 */
 # endif /* LDNS_BUILD_CONFIG_USE_DSA */
 
 /**
@@ -312,6 +361,8 @@ void ldns_key_set_algorithm(ldns_key *k, ldns_signing_algorithm l);
  */
 void ldns_key_set_evp_key(ldns_key *k, EVP_PKEY *e);
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * Set the key's rsa data.
  * The rsa data should be freed by the user.
@@ -321,6 +372,7 @@ void ldns_key_set_evp_key(ldns_key *k, EVP_PKEY *e);
 void ldns_key_set_rsa_key(ldns_key *k, RSA *r);
 
 # if LDNS_BUILD_CONFIG_USE_DSA
+OSSL_DEPRECATEDIN_3_0
 /**
  * Set the key's dsa data
  * The dsa data should be freed by the user.
@@ -330,6 +382,7 @@ void ldns_key_set_rsa_key(ldns_key *k, RSA *r);
 void ldns_key_set_dsa_key(ldns_key *k, DSA *d);
 # endif /* LDNS_BUILD_CONFIG_USE_DSA */
 
+OSSL_DEPRECATEDIN_3_0
 /**
  * Assign the key's rsa data
  * The rsa data will be freed automatically when the key is freed.
@@ -339,6 +392,7 @@ void ldns_key_set_dsa_key(ldns_key *k, DSA *d);
 void ldns_key_assign_rsa_key(ldns_key *k, RSA *r);
 
 # if LDNS_BUILD_CONFIG_USE_DSA
+OSSL_DEPRECATEDIN_3_0
 /**
  * Assign the key's dsa data
  * The dsa data will be freed automatically when the key is freed.
@@ -346,7 +400,8 @@ void ldns_key_assign_rsa_key(ldns_key *k, RSA *r);
  * \param[in] d the dsa data
  */
 void ldns_key_assign_dsa_key(ldns_key *k, DSA *d);
-# endif /* LDNS_BUILD_CONFIG_USE_DSA */
+#  endif /* LDNS_BUILD_CONFIG_USE_DSA */
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 /** 
  * Get the PKEY id for GOST, loads GOST into openssl as a side effect.
@@ -451,12 +506,15 @@ size_t ldns_key_list_key_count(const ldns_key_list *key_list);
 ldns_key *ldns_key_list_key(const ldns_key_list *key, size_t nr);
 
 #if LDNS_BUILD_CONFIG_HAVE_SSL
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * returns the (openssl) RSA struct contained in the key
  * \param[in] k the key to look in
  * \return the RSA * structure in the key
  */
 RSA *ldns_key_rsa_key(const ldns_key *k);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 /**
  * returns the (openssl) EVP struct contained in the key
  * \param[in] k the key to look in
@@ -465,10 +523,13 @@ RSA *ldns_key_rsa_key(const ldns_key *k);
 EVP_PKEY *ldns_key_evp_key(const ldns_key *k);
 
 # if LDNS_BUILD_CONFIG_USE_DSA
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 /**
  * returns the (openssl) DSA struct contained in the key
  */
 DSA *ldns_key_dsa_key(const ldns_key *k);
+#  endif /* OPENSSL_NO_DEPRECATED_3_0 */
 # endif /* LDNS_BUILD_CONFIG_USE_DSA */
 #endif /* LDNS_BUILD_CONFIG_HAVE_SSL */
 

--- a/ldns/util.h.in
+++ b/ldns/util.h.in
@@ -388,6 +388,7 @@ int b32_pton_extended_hex(const char* src_text, size_t src_text_length,
 
 #endif /* ! LDNS_BUILD_CONFIG_HAVE_B32_PTON */
 
+void ldns_swap_bytes(unsigned char *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/util.c
+++ b/util.c
@@ -792,3 +792,16 @@ b32_pton_extended_hex(const char* src, size_t src_sz,
 
 #endif /* ! HAVE_B32_PTON */
 
+void
+ldns_swap_bytes(unsigned char *buf, size_t len)
+{
+#if BYTE_ORDER == LITTLE_ENDIAN
+    size_t i, j, temp;
+    for(i = 0, j = len - 1; i < j; i++, j--) {
+        temp = buf[i];
+        buf[i] = buf[j];
+        buf[j] = temp;
+    }
+#endif
+}
+


### PR DESCRIPTION
A few days ago, I volunteered to contribute an OpenSSL 3 implementation that doesn't use any functions or types deprecated by OpenSSL 3 in #243. I realized as I was finishing this that I don't actually have a good way of testing this, so it probably shouldn't be merged as-is.

I tried running ./tests/test-all.sh, but many of the tests failed, even without my changes. I suspect my computer isn't set up to properly run the tests, plus there were some comments in there about the tests really only working on openbsd.

But I'm willing to help however I can to figure out how to get this all tested and merged.