### PR TITLE
Minor improvements to the ldns-signzone man page.

### DIFF
--- a/examples/ldns-signzone.1
+++ b/examples/ldns-signzone.1
@@ -16,8 +16,8 @@ KEY
 .SH DESCRIPTION
 
 \fBldns-signzone\fR is used to generate a DNSSEC signed zone. When run it
-will create a new zonefile that contains RRSIG and NSEC resource records, as
-specified in RFC 4033, RFC 4034 and RFC 4035.
+will create a new zonefile that contains RRSIG and NSEC(3) resource records,
+as specified in RFC 4033, RFC 4034 and RFC 4035.
 
 Keys must be specified by their base name (i.e. without .private). If
 the DNSKEY that belongs to the key in the .private file is not present
@@ -25,9 +25,9 @@ in the zone, it will be read from the file <base name>.key. If that
 file does not exist, the DNSKEY value will be generated from the
 private key.
 
-Multiple keys can be specified, Key Signing Keys are used as such when
+Multiple keys can be specified. Key Signing Keys are used as such when
 they are either already present in the zone, or specified in a .key
-file, and have the KSK bit set.
+file, and have the SEP bit set.
 
 .SH OPTIONS
 .TP


### PR DESCRIPTION
Note that zone output may also be NSEC3 hashed, not just NSEC hashed.

Refer to the SEP bit rather than the KSK bit as there is no KSK bit in a DNSKEY.