### PR TITLE
Clarify man page description of signzone `-d` argument.

### DIFF
--- a/examples/ldns-signzone.1
+++ b/examples/ldns-signzone.1
@@ -42,10 +42,7 @@ the comment text.
 
 .TP
 \fB-d\fR
-Normally, if the DNSKEY RR for a key that is used to sign the zone is
-not found in the zone file, it will be read from .key, or derived from
-the private key (in that order). This option turns that feature off,
-so that only the signatures are added to the zone.
+Do not add DNSKEY resource records for used keys to the signed zone.
 
 .TP
 \fB-e\fR \fIdate\fR


### PR DESCRIPTION
The `-d` argument only affects addition of DNSKEY RRs to the signed zone, it doesn't affect key file loading behaviour.