### PR TITLE
ldns_resolver_search_status: ensure returning pkt with LDNS_STATUS_OK

### DIFF
--- a/resolver.c
+++ b/resolver.c
@@ -1082,9 +1082,10 @@ ldns_resolver_search_status(ldns_pkt** pkt,
 						LDNS_RCODE_NOERROR) {
 
 					return LDNS_STATUS_OK;
+				} else if (i < ldns_resolver_searchlist_count(r)) {
+					ldns_pkt_free(*pkt);
+					*pkt = NULL;
 				}
-				ldns_pkt_free(*pkt);
-				*pkt = NULL;
 			}
 		}
 	}


### PR DESCRIPTION
Ensure we return a pkt by returning the final one in case the input is not an absolute dname and no error occurred getting a response packet.

The return of ldns_resolver_query_status can be LDNS_STATUS_OK, but the rcode from pkt an error.  In such case, when all search domains are exhausted and the final query is done on the input dname as is, *pkt is set freed and set to NULL, while s still is LDNS_STATUS_OK.  As a result, the function returns with LDNS_STATUS_OK and pkt NULL.

This particular return makes the caller unable to handle the return sensically, other than guessing there was an error of some sort.  By returning the last retrieved pkt, the caller is able to get the RCODE and return a meaningful error (such as SERVFAIL).