### PR TITLE
Fix RR Type AMTRELAY type nogateway

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -22,6 +22,8 @@
 	  when an already existing RR is tried to be added. This is a API
 	  change, hence this also bumps the version to 1.9.0
 	* PR #282: ensure returning pkt with LDNS_STATUS_OK. Thanks grobian.
+	* PR #286: Fix RR Type AMTRELAY type nogateway, to print relay '.',
+	  and memory leaks in parsing it.
 
 1.8.4	2024-07-19
 	* Fix building documentation in build directory.

--- a/host2str.c
+++ b/host2str.c
@@ -1422,6 +1422,8 @@ ldns_rdf2buffer_str_amtrelay(ldns_buffer *output, const ldns_rdf *rdf)
 			precedence, discovery_optional, relay_type);
 	if (relay)
 	  	(void) ldns_rdf2buffer_str(output, relay);
+	else
+		ldns_buffer_printf(output, ".");
 
 	ldns_rdf_deep_free(relay);
 	return ldns_buffer_status(output);

--- a/str2host.c
+++ b/str2host.c
@@ -1830,6 +1830,7 @@ ldns_str2rdf_amtrelay(ldns_rdf **rd, const char *str)
 			LDNS_FREE(relay);
 		LDNS_FREE(token);
 		ldns_buffer_free(str_buf);
+		ldns_rdf_deep_free(relay_rdf);
 		return LDNS_STATUS_INVALID_STR;
 	}
 
@@ -1845,7 +1846,7 @@ ldns_str2rdf_amtrelay(ldns_rdf **rd, const char *str)
 			LDNS_FREE(relay);
 		LDNS_FREE(token);
 		ldns_buffer_free(str_buf);
-		if (relay_rdf) ldns_rdf_free(relay_rdf);
+		ldns_rdf_deep_free(relay_rdf);
 		return LDNS_STATUS_MEM_ERR;
 	}
 
@@ -1864,7 +1865,7 @@ ldns_str2rdf_amtrelay(ldns_rdf **rd, const char *str)
 		LDNS_FREE(relay);
 	LDNS_FREE(token);
 	ldns_buffer_free(str_buf);
-	ldns_rdf_free(relay_rdf);
+	ldns_rdf_deep_free(relay_rdf);
 	LDNS_FREE(data);
 	if(!*rd) return LDNS_STATUS_MEM_ERR;
 	return LDNS_STATUS_OK;

--- a/zone.c
+++ b/zone.c
@@ -350,7 +350,7 @@ error:
 		ldns_rdf_deep_free(my_prev);
 	}
 	if (newzone) {
-		ldns_zone_free(newzone);
+		ldns_zone_deep_free(newzone);
 	}
 	return ret;
 }


### PR DESCRIPTION
Fix RR Type AMTRELAY type nogateway to print a relay of '.', RFC8777.

The RFC says, https://www.rfc-editor.org/rfc/rfc8777.html#section-4.3.1-2 , that there should be relay of '.' for type 0 (no gateway).

The parse code in ldns for type AMTRELAY seems to be fine for this, but the print out code did not print the '.'. This fixes that, similar to the simdzone fix of the same type.