### PR TITLE
Skip definition of bool on -std=c23 or newer

### DIFF
--- a/ldns/common.h.in
+++ b/ldns/common.h.in
@@ -40,6 +40,10 @@
  */
 /*@ignore@*/
 /* splint barfs on this construct */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+/* c23 defines bool already and deprecates stdbool.h */
+#define __bool_true_false_are_defined
+#endif
 #ifndef __bool_true_false_are_defined
 # ifdef HAVE_STDBOOL_H
 #  include <stdbool.h>


### PR DESCRIPTION
Fedora gcc compiler switched to c23 standard by default. It now does not compile ldns in default settings.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2416980