### PR TITLE
ldns-config: put $LIBS after -lldns

### DIFF
--- a/packaging/ldns-config.in
+++ b/packaging/ldns-config.in
@@ -26,11 +26,11 @@ do
     fi
     if [ $arg = "--libs" ]
     then
-        echo "${LDFLAGS} -L${LIBDIR} ${LIBS} -lldns"
+        echo "${LDFLAGS} -L${LIBDIR} -lldns ${LIBS}"
     fi
     if [ $arg = "--python-libs" ]
     then
-        echo "${LDFLAGS} ${PYTHON_LDFLAGS} -L${LIBDIR} ${LIBS} -lldns"
+        echo "${LDFLAGS} ${PYTHON_LDFLAGS} -L${LIBDIR} -lldns ${LIBS}"
     fi
     if [ $arg = "-h" ] || [ $arg = "--help" ]
     then


### PR DESCRIPTION
Since $LIBS is the set of libraries used by -lldns, they need to come *after* it, not before, in order for the linker to properly check. This can be seen when using static libs e.g. `-static -lcrypto -lldns` as the OpenSSL crypto lib will be dropped by the linker since there are no references when processed, and then -lldns fails due to undefined symbols.