### PR TITLE
Remote DoS on maliciously crafted answer

### DIFF
--- a/ldns/buffer.h
+++ b/ldns/buffer.h
@@ -356,11 +356,13 @@ ldns_buffer_available(const ldns_buffer *buffer, size_t count)
  * \param[in] data pointer to the data to write to the buffer
  * \param[in] count the number of bytes of data to write
  */
-INLINE void
+INLINE size_t
 ldns_buffer_write_at(ldns_buffer *buffer, size_t at, const void *data, size_t count)
 {
-	assert(ldns_buffer_available_at(buffer, at, count));
-	memcpy(buffer->_data + at, data, count);
+	size_t avail = ldns_buffer_remaining_at(buffer, at);
+	size_t copy = count < avail ? count : avail;
+	memcpy(buffer->_data + at, data, copy);
+	return copy;
 }
 
 /**
@@ -372,8 +374,8 @@ ldns_buffer_write_at(ldns_buffer *buffer, size_t at, const void *data, size_t co
 INLINE void
 ldns_buffer_write(ldns_buffer *buffer, const void *data, size_t count)
 {
-	ldns_buffer_write_at(buffer, buffer->_position, data, count);
-	buffer->_position += count;
+	size_t copied = ldns_buffer_write_at(buffer, buffer->_position, data, count);
+	buffer->_position += copied;
 }
 
 /**

--- a/str2host.c
+++ b/str2host.c
@@ -392,7 +392,7 @@ ldns_str2rdf_dname(ldns_rdf **d, const char *str)
 	/* root label */
 	if (1 == len && *str == '.') {
 		*d = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_DNAME, 1, "\0");
-		return LDNS_STATUS_OK;
+		return *d?LDNS_STATUS_OK:LDNS_STATUS_MEM_ERR;
 	}
 
 	/* get on with the rest */
@@ -457,7 +457,7 @@ ldns_str2rdf_dname(ldns_rdf **d, const char *str)
 	len++;
 
 	*d = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_DNAME, len, buf);
-	return LDNS_STATUS_OK;
+	return *d?LDNS_STATUS_OK:LDNS_STATUS_MEM_ERR;
 }
 
 ldns_status


### PR DESCRIPTION
* buffer: don't bail out when request is bigger than buffer
to prevent remote DoS by malicious DNS repsonses, don't bail out
with assert(), but copy as much as possible.
This will probably lead to incomplete response, but the error
handling of ldns will take over and the process will not just be
killed.
Issue found by Maciej Musial, Robert Rozanski and Monika Walendzik.

* ldns_str2rdf_dname: check for successful mallocs
ldns_str2rdf_dname() is calling ldns_rdf_new_frm_data() but was not
checking the return value for valid allocated memory.
This could cause NULL pointer derefs in following code.
Correcting this and returning LDNS_STATUS_MEM_ERR on failed mallocs.

