### PR TITLE
rr: limit the amount of allowed rr descriptors

### DIFF
--- a/ldns/rr.h
+++ b/ldns/rr.h
@@ -36,6 +36,13 @@ extern "C" {
 /** The bytes TTL, CLASS and length use up in an rr */
 #define LDNS_RR_OVERHEAD	10
 
+/**
+ * Maximum amount of supported rr descriptors
+ * if this is not limited, the memory usage of the ldns process
+ * could grow to several 100MiB's, which could result in remote
+ * DoS on maliciously crafted responses
+ */
+#define LDNS_RR_MAX_DESCRIPTORS  255
 
 
 /**

--- a/rr.c
+++ b/rr.c
@@ -2765,16 +2765,19 @@ ldns_rr_descriptor_minimum(const ldns_rr_descriptor *descriptor)
 size_t
 ldns_rr_descriptor_maximum(const ldns_rr_descriptor *descriptor)
 {
+	size_t ret_val = 0;
 	if (descriptor) {
 		if (descriptor->_variable != LDNS_RDF_TYPE_NONE) {
 			/* Should really be SIZE_MAX... bad FreeBSD.  */
-			return UINT_MAX;
+			ret_val = UINT_MAX;
 		} else {
-			return descriptor->_maximum;
+			ret_val = descriptor->_maximum;
 		}
-	} else {
-		return 0;
 	}
+	if (ret_val > LDNS_RR_MAX_DESCRIPTORS) {
+		ret_val = LDNS_RR_MAX_DESCRIPTORS;
+	}
+	return ret_val;
 }
 
 ldns_rdf_type


### PR DESCRIPTION
A malicious DNS server could send an answer causing ldns to assume millions of rr descriptors.
This could cause ldns consuming hundrets of MiB's of memory which then could cause the OOM handler to step in and kill the process.

Thus we want to limit the amount of allowed descriptors to prevent this from being used as remote DoS attacks.

Issue found by Maciej Musial, Robert Rozanski and Monika Walendzik.