### PR TITLE
Fix #276: remove incorrect keytag+1 heuristic in find_key_in_zone

### DIFF
--- a/examples/ldns-signzone.c
+++ b/examples/ldns-signzone.c
@@ -197,13 +197,7 @@ find_key_in_zone(ldns_rr *pubkey_gen, ldns_zone *zone) {
 		key_i++) {
 		pubkey = ldns_rr_list_rr(ldns_zone_rrs(zone), key_i);
 		if (ldns_rr_get_type(pubkey) == LDNS_RR_TYPE_DNSKEY &&
-			(ldns_calc_keytag(pubkey)
-				==
-				ldns_calc_keytag(pubkey_gen) ||
-					 /* KSK has gen-keytag + 1 */
-					 ldns_calc_keytag(pubkey)
-					 ==
-					 ldns_calc_keytag(pubkey_gen) + 1) 
+			ldns_calc_keytag(pubkey) == ldns_calc_keytag(pubkey_gen)
 			   ) {
 				if (verbosity >= 2) {
 					fprintf(stderr, "Found it in the zone!\n");
@@ -293,9 +287,8 @@ find_or_create_pubkey(const char *keyfile_name_base, ldns_key *key, ldns_zone *o
 
 	if (verbosity >= 2) {
 		fprintf(stderr,
-			   "Looking for key with keytag %u or %u\n",
-			   (unsigned int) ldns_calc_keytag(pubkey_gen),
-			   (unsigned int) ldns_calc_keytag(pubkey_gen)+1
+			   "Looking for key with keytag %u\n",
+			   (unsigned int) ldns_calc_keytag(pubkey_gen)
 			   );
 	}
 


### PR DESCRIPTION
When searching for a key's public RR in the zone, find_key_in_zone() also accepted keys with keytag == pubkey_gen_keytag + 1, based on an old assumption that KSK keytags are always ZSK keytag + 1.

This is not guaranteed and causes a bug: if the KSK's keytag happens to equal ZSK keytag + 1, the KSK is incorrectly returned as the ZSK's public key match, and is subsequently excluded from the signed zone as a standalone DNSKEY record, breaking DNSSEC validation.

Fix by matching on exact keytag only. The SEP flag (LDNS_KEY_SEP_KEY) is the correct way to distinguish KSK from ZSK, and the caller already handles KSK lookup separately via ldns_key_flags().