### PR TITLE
Improve reporting of malformed RRSIG signatures

### DIFF
--- a/dnssec.c
+++ b/dnssec.c
@@ -1931,7 +1931,7 @@ ldns_convert_ecdsa_rrsig_rdf2asn1(ldns_buffer *target_buffer,
         uint8_t* d = ldns_rdf_data(sig_rdf);
         /* if too short, or not even length, do not bother */
         if(bnsize < 16 || (size_t)bnsize*2 != ldns_rdf_size(sig_rdf))
-                return LDNS_STATUS_ERR;
+                return LDNS_STATUS_SYNTAX_RDATA_ERR;
         /* strip leading zeroes from r (but not last one) */
         while(r_rem < bnsize-1 && d[r_rem] == 0)
                 r_rem++;

--- a/dnssec_verify.c
+++ b/dnssec_verify.c
@@ -2157,7 +2157,8 @@ static ldns_status
 ldns_rrsig2rawsig_buffer(ldns_buffer* rawsig_buf, const ldns_rr* rrsig)
 {
 	uint8_t sig_algo;
-       
+	ldns_status status;
+
 	if (rrsig == NULL) {
 		return LDNS_STATUS_CRYPTO_NO_RRSIG;
 	}
@@ -2204,14 +2205,11 @@ ldns_rrsig2rawsig_buffer(ldns_buffer* rawsig_buf, const ldns_rr* rrsig)
 		if (ldns_rr_rdf(rrsig, 8) == NULL) {
 			return LDNS_STATUS_MISSING_RDATA_FIELDS_RRSIG;
 		}
-		if (ldns_convert_dsa_rrsig_rdf2asn1(
-					rawsig_buf, ldns_rr_rdf(rrsig, 8)) 
-				!= LDNS_STATUS_OK) {
-			/*
-			  if (ldns_rdf2buffer_wire(rawsig_buf,
-			  ldns_rr_rdf(rrsig, 8)) != LDNS_STATUS_OK) {
-			*/
-			return LDNS_STATUS_MEM_ERR;
+
+		status = ldns_convert_dsa_rrsig_rdf2asn1(
+				rawsig_buf, ldns_rr_rdf(rrsig, 8));
+		if (status != LDNS_STATUS_OK) {
+			return status;
 		}
 		break;
 #endif
@@ -2223,12 +2221,13 @@ ldns_rrsig2rawsig_buffer(ldns_buffer* rawsig_buf, const ldns_rr* rrsig)
 		if (ldns_rr_rdf(rrsig, 8) == NULL) {
 			return LDNS_STATUS_MISSING_RDATA_FIELDS_RRSIG;
 		}
-		if (ldns_convert_ecdsa_rrsig_rdf2asn1(
-					rawsig_buf, ldns_rr_rdf(rrsig, 8))
-				!= LDNS_STATUS_OK) {
-			return LDNS_STATUS_MEM_ERR;
-                }
-                break;
+
+		status = ldns_convert_ecdsa_rrsig_rdf2asn1(
+			    rawsig_buf, ldns_rr_rdf(rrsig, 8));
+		if (status != LDNS_STATUS_OK) {
+			return status;
+		}
+		break;
 #endif
 	case LDNS_DH:
 	case LDNS_ECC:


### PR DESCRIPTION
When verifying an RRset signed with algorithm 13, e.g. with `ldns_verify_time()`, if the corresponding RRSIG’s signature is malformed, the verification fails (as it should) but the status code being returned is `LDNS_STATUS_MEM_ERR` (“General memory error”). Which may lead someone to wrongly believe that there is a serious problem with LDNS.

For DNSSEC signatures made with cipher suites based on DSA and ECDSA, LDNS converts the signature from its DNS wire format to ASN.1 for compatibility with OpenSSL (see `ldns_convert_dsa_rrsig_rdf2asn1()` and `ldns_convert_ecdsa_rrsig_rdf2asn1()`). This conversion can fail, either because of memory allocation failures or because of bad input.

However, the caller (`ldns_rrsig2rawsig_buffer()`) wrongly assumed that if the conversion failed, it is necessary a “general memory error”, hence turning an error caused by bad input (i.e. a malformed signature in an RRSIG) into a misleading error.

With this commit, errors raised by `ldns_convert_{dsa,ecdsa}_rrsig_rdf2asn1()` are properly propagated back up the caller chain. That way, if verifying a signature fails because the RRSIG’s signature is malformed, the ldns_status is `LDNS_STATUS_SYNTAX_RDATA_ERR` instead of `LDNS_STATUS_MEM_ERR`.

(See also: https://github.com/zonemaster/zonemaster-engine/issues/1512 for an example of how the problem addressed by this PR made diagnosis harder).