### PR TITLE
Fix -Wundef warning in sha2.c

### DIFF
--- a/sha1.c
+++ b/sha1.c
@@ -17,7 +17,8 @@
 /* #define LITTLE_ENDIAN * This should be #define'd already, if true. */
 
 #include <ldns/config.h>
-#include <ldns/ldns.h>
+#include <ldns/common.h>
+#include <ldns/sha1.h>
 #include <strings.h>
 
 #define SHA1HANDSOFF 1 /* Copies data before messing with it. */

--- a/sha2.c
+++ b/sha2.c
@@ -41,6 +41,7 @@
  */
 
 #include <ldns/config.h>
+#include <ldns/common.h>
 #include <string.h>	/* memcpy()/memset() or bcopy()/bzero() */
 #include <assert.h>	/* assert() */
 #include <ldns/sha2.h>


### PR DESCRIPTION
When `-Wundef` is specified, compiling sha2.c would give the following warning:

```
In file included from ./sha2.c:46:
./ldns/sha2.h:52:5: warning: ‘LDNS_BUILD_CONFIG_HAVE_INTTYPES_H’ is not defined, evaluates to ‘0’ [-Wundef]
   52 | #if LDNS_BUILD_CONFIG_HAVE_INTTYPES_H
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fix this warning by adding the necessary `<ldns/common.h>` include to `sha2.c`.

Meanwhile, adjust `sha1.c` to only include necessary headers, similar to `sha2.c`.