### PR TITLE
dnssec: handle unsupported NSEC3 hash algorithms without aborting

### DIFF
--- a/dnssec.c
+++ b/dnssec.c
@@ -148,6 +148,13 @@ ldns_dnssec_nsec3_closest_encloser(const ldns_rdf *qname,
 									 iterations,
 									 salt_length,
 									 salt);
+		/* only SHA-1 is implemented; unsupported algorithms return NULL */
+		if (!hashed_sname) {
+			LDNS_FREE(salt);
+			ldns_rdf_deep_free(zone_name);
+			ldns_rdf_deep_free(sname);
+			return NULL;
+		}
 
 		status = ldns_dname_cat(hashed_sname, zone_name);
                 if(status != LDNS_STATUS_OK) {
@@ -889,12 +896,20 @@ ldns_dnssec_create_nsec3(const ldns_dnssec_name *from,
 	}
 
 	nsec_rr = ldns_rr_new_frm_type(LDNS_RR_TYPE_NSEC3);
-	ldns_rr_set_owner(nsec_rr,
-	                  ldns_nsec3_hash_name(ldns_dnssec_name_name(from),
-	                  algorithm,
-	                  iterations,
-	                  salt_length,
-	                  salt));
+	{
+		ldns_rdf *hashed_owner;
+
+		hashed_owner = ldns_nsec3_hash_name(ldns_dnssec_name_name(from),
+		                  algorithm,
+		                  iterations,
+		                  salt_length,
+		                  salt);
+		if (!hashed_owner) {
+			ldns_rr_free(nsec_rr);
+			return NULL;
+		}
+		ldns_rr_set_owner(nsec_rr, hashed_owner);
+	}
 	status = ldns_dname_cat(ldns_rr_owner(nsec_rr), zone_name);
         if(status != LDNS_STATUS_OK) {
                 ldns_rr_free(nsec_rr);
@@ -1208,6 +1223,9 @@ ldns_create_nsec3(const ldns_rdf *cur_owner,
 								 iterations,
 								 salt_length,
 								 salt);
+	if (!hashed_owner) {
+		return NULL;
+	}
 	status = ldns_dname_cat(hashed_owner, cur_zone);
         if(status != LDNS_STATUS_OK) {
 		ldns_rdf_deep_free(hashed_owner);

--- a/dnssec_verify.c
+++ b/dnssec_verify.c
@@ -1624,6 +1624,11 @@ ldns_dnssec_verify_denial_nsec3_match( ldns_rr *rr
                 }
 
 		wildcard = ldns_dname_new_frm_str("*");
+		if (!wildcard) {
+			ldns_rdf_deep_free(closest_encloser);
+			result = LDNS_STATUS_MEM_ERR;
+			goto done;
+		}
 		(void) ldns_dname_cat(wildcard, closest_encloser);
 
 		for (i = 0; i < ldns_rr_list_rr_count(nsecs); i++) {
@@ -1631,6 +1636,13 @@ ldns_dnssec_verify_denial_nsec3_match( ldns_rr *rr
 				ldns_nsec3_hash_name_frm_nsec3(ldns_rr_list_rr(nsecs, 0),
 										 wildcard
 										 );
+			/* hash returns NULL for unsupported algorithms (only SHA-1) */
+			if (!hashed_wildcard_name) {
+				ldns_rdf_deep_free(closest_encloser);
+				ldns_rdf_deep_free(wildcard);
+				result = LDNS_STATUS_CRYPTO_ALGO_NOT_IMPL;
+				goto done;
+			}
 			(void) ldns_dname_cat(hashed_wildcard_name, zone_name);
 
 			if (ldns_nsec_covers_name(ldns_rr_list_rr(nsecs, i),
@@ -1656,6 +1668,10 @@ ldns_dnssec_verify_denial_nsec3_match( ldns_rr *rr
 		hashed_name = ldns_nsec3_hash_name_frm_nsec3(
 		                   ldns_rr_list_rr(nsecs, 0),
 		                   ldns_rr_owner(rr));
+		if (!hashed_name) {
+			result = LDNS_STATUS_CRYPTO_ALGO_NOT_IMPL;
+			goto done;
+		}
 		(void) ldns_dname_cat(hashed_name, zone_name);
 		for (i = 0; i < ldns_rr_list_rr_count(nsecs); i++) {
 			if (ldns_dname_compare(hashed_name,
@@ -1688,11 +1704,22 @@ ldns_dnssec_verify_denial_nsec3_match( ldns_rr *rr
 			goto done;
 		}
 		wildcard = ldns_dname_new_frm_str("*");
+		if (!wildcard) {
+			ldns_rdf_deep_free(closest_encloser);
+			result = LDNS_STATUS_MEM_ERR;
+			goto done;
+		}
 		(void) ldns_dname_cat(wildcard, closest_encloser);
 		for (i = 0; i < ldns_rr_list_rr_count(nsecs); i++) {
 			hashed_wildcard_name =
 				ldns_nsec3_hash_name_frm_nsec3(ldns_rr_list_rr(nsecs, 0),
 					 wildcard);
+			if (!hashed_wildcard_name) {
+				ldns_rdf_deep_free(closest_encloser);
+				ldns_rdf_deep_free(wildcard);
+				result = LDNS_STATUS_CRYPTO_ALGO_NOT_IMPL;
+				goto done;
+			}
 			(void) ldns_dname_cat(hashed_wildcard_name, zone_name);
 
 			if (ldns_dname_compare(hashed_wildcard_name,
@@ -1725,6 +1752,10 @@ ldns_dnssec_verify_denial_nsec3_match( ldns_rr *rr
 														 0),
 											ldns_rr_owner(rr)
 											);
+		if (!hashed_name) {
+			result = LDNS_STATUS_CRYPTO_ALGO_NOT_IMPL;
+			goto done;
+		}
 		(void) ldns_dname_cat(hashed_name, zone_name);
 		for (i = 0; i < ldns_rr_list_rr_count(nsecs); i++) {
 			if (ldns_dname_compare(hashed_name,
@@ -1781,8 +1812,13 @@ ldns_dnssec_verify_denial_nsec3_match( ldns_rr *rr
 					ldns_rr_list_rr(nsecs, 0),
 					next_closer
 					);
-			(void) ldns_dname_cat(hashed_next_closer, zone_name);
 			ldns_rdf_deep_free(next_closer);
+			if (!hashed_next_closer) {
+				ldns_rdf_deep_free(closest_encloser);
+				result = LDNS_STATUS_CRYPTO_ALGO_NOT_IMPL;
+				goto done;
+			}
+			(void) ldns_dname_cat(hashed_next_closer, zone_name);
 		}
 		/* Find the NSEC3 that covers the "next closer" */
 		for (i = 0; i < ldns_rr_list_rr_count(nsecs); i++) {


### PR DESCRIPTION
Fixes #307

`ldns_nsec3_hash_name()` only implements SHA-1 (algorithm 1) and returns NULL for any other algorithm. Several callers in the NSEC3 denial path then passed that NULL into `ldns_dname_cat()` → `ldns_rdf_get_type()`, which aborts on `assert(rd != NULL)`.

I hit this while checking the path described in #307: a crafted NSEC3 with algorithm 2 is enough to take down anything that calls `ldns_dnssec_verify_denial_nsec3()` with assertions enabled.

### What changed

- `ldns_dnssec_nsec3_closest_encloser()`: check the hash result before `ldns_dname_cat` (this is the first crash site on the NXDOMAIN path).
- `ldns_dnssec_verify_denial_nsec3_match()`: NULL-check every `ldns_nsec3_hash_name_frm_nsec3()` result and return `LDNS_STATUS_CRYPTO_ALGO_NOT_IMPL` (and free intermediate rdfs). Also handle `ldns_dname_new_frm_str("*")` allocation failure.
- Same NULL guard on the NSEC3 *creation* helpers that feed the hash result into `ldns_dname_cat` / `ldns_rr_set_owner`.

### How I checked it

Built libldns from this tree and ran two small harnesses:

1. Hash root cause — algorithm 1 returns a name, algorithms 0/2/255 return NULL.
2. Denial entry point — with the unpatched objects, algo=2 aborts (`rdata.c:33`, exit 134). With the patch, the same call returns a normal status code and does not abort.

Happy to add the harnesses under `test/` if that would help.
